### PR TITLE
StaticAssetsRequestHandler now also has a staticAssetsPath property

### DIFF
--- a/src/main/java/org/craftercms/engine/controller/StaticAssetsRequestHandler.java
+++ b/src/main/java/org/craftercms/engine/controller/StaticAssetsRequestHandler.java
@@ -51,11 +51,11 @@ public class StaticAssetsRequestHandler extends WebContentGenerator implements H
     private static final Log logger = LogFactory.getLog(StaticAssetsRequestHandler.class);
 
     private ContentStoreService contentStoreService;
-    private String[] bypassFolderList;
+    private String staticAssetsPath;
 
     public StaticAssetsRequestHandler() {
         super(METHOD_GET, METHOD_HEAD);
-        bypassFolderList = new String[0];
+
         setRequireSession(false);
     }
 
@@ -64,8 +64,8 @@ public class StaticAssetsRequestHandler extends WebContentGenerator implements H
         this.contentStoreService = contentStoreService;
     }
 
-    public void setBypassFolderList(String bypassFolderList) {
-        this.bypassFolderList = bypassFolderList.split(",");
+    public void setStaticAssetsPath(String staticAssetsPath) {
+        this.staticAssetsPath = staticAssetsPath;
     }
 
     @Override
@@ -127,13 +127,12 @@ public class StaticAssetsRequestHandler extends WebContentGenerator implements H
             throw new IllegalStateException("Required request attribute '" + HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE +
                     "' is not set");
         }
-        // TODO: Remove this. This is kinda ugly.
-        String pattern = (String)request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-        for (String folder : bypassFolderList) {
-            if (pattern.startsWith(folder))
-                return UrlUtils.appendUrl(folder, path);
+
+        if (StringUtils.isNotEmpty(staticAssetsPath)) {
+            return UrlUtils.appendUrl(staticAssetsPath, path);
+        } else {
+            return UrlUtils.appendUrl(context.getStaticAssetsPath(), path);
         }
-        return UrlUtils.appendUrl(context.getStaticAssetsPath(), path);
     }
 
     protected Content getContent(SiteContext context, String path) {

--- a/src/main/java/org/craftercms/engine/macro/impl/AbstractMacro.java
+++ b/src/main/java/org/craftercms/engine/macro/impl/AbstractMacro.java
@@ -21,8 +21,8 @@ import org.craftercms.engine.macro.Macro;
 import javax.annotation.PostConstruct;
 
 /**
- * Abstract {@link org.craftercms.engine.macro.Macro} that provides a macro name attribute to hold the macro name (when the macro's name is variable) and
- * the ability to skip the macro if the name is not contained in the specified string.
+ * Abstract {@link org.craftercms.engine.macro.Macro} that provides a macro name attribute to hold the macro name (when the macro's name
+ * is variable) and the ability to skip the macro if the name is not contained in the specified string.
  *
  * @author Alfonso Vásquez
  */


### PR DESCRIPTION
StaticAssetsRequestHandler now also has a staticAssetsPath property, which will be used if specified instead of the SiteContext.getStaticAssetsPath. Used to have several StaticAssetsRequestHandler for different paths.
