### PR TITLE
Added (temporarily) crafter.engine.scheduler.threads.pool.size back

### DIFF
--- a/src/main/resources/crafter/engine/server-config.properties
+++ b/src/main/resources/crafter/engine/server-config.properties
@@ -160,3 +160,5 @@ crafter.engine.environment=local
 crafter.engine.https.port=443
 # The access token ID used by this instance of Engine to make requests to Crafter Profile
 crafter.profile.rest.client.accessToken.id=b4d44030-d0af-11e3-9c1a-0800200c9a66
+
+crafter.engine.scheduler.threads.pool.size=1


### PR DESCRIPTION
Added (temporarily) crafter.engine.scheduler.threads.pool.size back. Will be removed after Studio's contexts are migrated to the new overlay contexts.