### PR TITLE
Small bug fix

### DIFF
--- a/src/main/resources/crafter/engine/rendering/main-rendering-context.xml
+++ b/src/main/resources/crafter/engine/rendering/main-rendering-context.xml
@@ -92,12 +92,6 @@
         <ref bean="crafter.localeChangeInterceptor"/>
     </util:list>
 
-    <!-- ////////////////////////////////// -->
-    <!--								 	-->
-    <!--			 Locale 				-->
-    <!--									-->
-    <!-- ////////////////////////////////// -->
-
     <!-- This needs to be named localeResolver so that the DispatcherServlet can find it -->
     <bean id="localeResolver" class="org.craftercms.engine.targeting.impl.ConfigAwareCookieLocaleResolver" />
 

--- a/src/main/resources/crafter/engine/services/url-transformation-context.xml
+++ b/src/main/resources/crafter/engine/services/url-transformation-context.xml
@@ -74,7 +74,7 @@
 
     <bean id="crafter.toCurrentTargetedUrlTransformer" class="org.craftercms.engine.url.ToTargetedUrlTransformer">
         <property name="targetedUrlStrategy" ref="crafter.proxyTargetedUrlStrategy"/>
-        <property name="forceCurrentTargetId" value="true"/>
+        <property name="forceCurrentTargetId" value="false"/>
     </bean>
 
     <bean id="crafter.replacePageExtWithDescriptorExtUrlTransformer"


### PR DESCRIPTION
* crafter.toCurrentTargetedUrlTransformer won't force current target ID. This way localized navigation trees are generated correctly.