### PR TITLE
 Engine now doesn't support _s, _t and _html on disable full model conversion

### DIFF
--- a/src/main/java/org/craftercms/engine/util/converters/ElementSuffixBasedConverter.java
+++ b/src/main/java/org/craftercms/engine/util/converters/ElementSuffixBasedConverter.java
@@ -16,9 +16,9 @@
  */
 package org.craftercms.engine.util.converters;
 
-import java.util.Date;
 import java.util.Map;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.craftercms.commons.converters.Converter;
@@ -30,11 +30,22 @@ public class ElementSuffixBasedConverter implements Converter<Element, Object> {
 
     private static final Log logger = LogFactory.getLog(ElementSuffixBasedConverter.class);
 
+    public static final String[] DEFAULT_SUPPORTED_SUFFIXES_ON_DISABLED_FULL_MODEL_CONVERSION =  { "i", "l", "b", "f", "d" };
+
     protected Map<String, Converter<String, ?>> suffixMappedConverters;
+    protected String[] supportedSuffixesOnDisabledFullModelTypeConversion;
+
+    public ElementSuffixBasedConverter() {
+        supportedSuffixesOnDisabledFullModelTypeConversion = DEFAULT_SUPPORTED_SUFFIXES_ON_DISABLED_FULL_MODEL_CONVERSION;
+    }
 
     @Required
     public void setSuffixMappedConverters(Map<String, Converter<String, ?>> suffixMappedConverters) {
         this.suffixMappedConverters = suffixMappedConverters;
+    }
+
+    public void setSupportedSuffixesOnDisabledFullModelTypeConversion(String[] supportedSuffixesOnDisabledFullModelTypeConversion) {
+        this.supportedSuffixesOnDisabledFullModelTypeConversion = supportedSuffixesOnDisabledFullModelTypeConversion;
     }
 
     @Override
@@ -57,7 +68,8 @@ public class ElementSuffixBasedConverter implements Converter<Element, Object> {
             Converter<String, ?> converter = suffixMappedConverters.get(converterId);
 
             if (converter != null) {
-                if (!converter.getTargetClass().equals(Date.class) || !SiteProperties.isDisableFullModelTypeConversion()) {
+                if (!SiteProperties.isDisableFullModelTypeConversion() ||
+                    ArrayUtils.contains(supportedSuffixesOnDisabledFullModelTypeConversion, converterId)) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Converting value of <" + name + "> to " + converter.getTargetClass().getName());
                     }


### PR DESCRIPTION
Engine only supports _i, _l, _b, _f, _d, to emulate the same behavior of 2.5. Now even if new prefixes are added they will be ignored if the disabled flag is true.

Ticket: craftercms/craftercms#1870