### PR TITLE
Better Standart serialization for engine.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,28 @@
     <build>
         <finalName>ROOT</finalName>
         <plugins>
+         <plugin>
+              <groupId>org.owasp</groupId>
+              <artifactId>dependency-check-maven</artifactId>
+              <version>3.1.1</version>
+              <configuration>
+              <!--
+                  	None 	0.0
+                    Low 	0.1-3.9
+                    Medium 	4.0-6.9
+                    High 	7.0-8.9
+  	            	Critical 	9.0-10.0
+              -->
+              <failBuildOnCVSS>5</failBuildOnCVSS>
+              </configuration>
+              <executions>
+                  <execution>
+                      <goals>
+                          <goal>check</goal>
+                      </goals>
+                  </execution>
+              </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -218,28 +218,7 @@
     <build>
         <finalName>ROOT</finalName>
         <plugins>
-         <plugin>
-              <groupId>org.owasp</groupId>
-              <artifactId>dependency-check-maven</artifactId>
-              <version>3.1.1</version>
-              <configuration>
-              <!--
-                  	None 	0.0
-                    Low 	0.1-3.9
-                    Medium 	4.0-6.9
-                    High 	7.0-8.9
-  	            	Critical 	9.0-10.0
-              -->
-              <failBuildOnCVSS>5</failBuildOnCVSS>
-              </configuration>
-              <executions>
-                  <execution>
-                      <goals>
-                          <goal>check</goal>
-                      </goals>
-                  </execution>
-              </executions>
-            </plugin>
+         
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>

--- a/src/main/resources/crafter/engine/rendering/main-rendering-context.xml
+++ b/src/main/resources/crafter/engine/rendering/main-rendering-context.xml
@@ -67,6 +67,28 @@
         <property name="objectMapper" ref="crafter.coreObjectMapper"/>
     </bean>
 
+    <bean id="crafter.coreObjectMapper" class="org.craftercms.commons.jackson.CustomSerializationObjectMapper">
+        <property name="dateFormat">
+            <bean class="java.text.SimpleDateFormat">
+                <constructor-arg value="yyyy-MM-dd'T'HH:mm:ssXXX"/>
+            </bean>
+        </property>
+        <property name="serializers">
+            <list>
+                <bean class="org.craftercms.commons.jackson.ObjectIdSerializer"/>
+                <bean class="org.craftercms.core.util.json.jackson.Dom4jDocumentJsonSerializer"/>
+                <bean class="com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer" />
+            </list>
+        </property>
+        <property name="deserializers">
+            <map>
+                <entry key="org.bson.types.ObjectId">
+                    <bean class="org.craftercms.commons.jackson.ObjectIdDeserializer"/>
+                </entry>
+            </map>
+        </property>
+    </bean>
+
     <bean id="crafter.xmlMsgConverter" class="org.springframework.http.converter.xml.MarshallingHttpMessageConverter">
         <constructor-arg ref="crafter.xmlMarshaller"/>
     </bean>

--- a/src/main/resources/crafter/engine/rendering/main-rendering-context.xml
+++ b/src/main/resources/crafter/engine/rendering/main-rendering-context.xml
@@ -68,11 +68,11 @@
     </bean>
 
     <bean id="crafter.coreObjectMapper" class="org.craftercms.commons.jackson.CustomSerializationObjectMapper">
-        <property name="dateFormat">
-            <bean class="java.text.SimpleDateFormat">
-                <constructor-arg value="yyyy-MM-dd'T'HH:mm:ssXXX"/>
-            </bean>
-        </property>
+        <!--<property name="dateFormat">-->
+            <!--<bean class="java.text.SimpleDateFormat">-->
+                <!--<constructor-arg value="yyyy-MM-dd'T'HH:mm:ssXXX"/>-->
+            <!--</bean>-->
+        <!--</property>-->
         <property name="serializers">
             <list>
                 <bean class="org.craftercms.commons.jackson.ObjectIdSerializer"/>


### PR DESCRIPTION
This PR will override the Core's `crafter.coreObjectMappe` bean to add Timezone, ObjectId and ISO date format.
 
This bean is a very generic and its borrow from craftercms/studio a new feature should be added to allow each site to change the way objects are serialized and deserializes. 

The date format was left as a comment since it might break existing API that expects the date time in a given format but users might want to have it ISO format with timezone.