### PR TITLE
*DRAFT PR* CookieSiteResolver uses default sitename if no parameter or cookie found

### DIFF
--- a/src/main/java/org/craftercms/engine/service/context/CookieSiteResolver.java
+++ b/src/main/java/org/craftercms/engine/service/context/CookieSiteResolver.java
@@ -36,10 +36,15 @@ public class CookieSiteResolver implements SiteResolver {
     private static final Log logger = LogFactory.getLog(CookieSiteResolver.class);
 
     protected String paramOrCookieName;
+    protected String defaultSiteName;
 
     @Required
     public void setParamOrCookieName(String paramOrCookieName) {
         this.paramOrCookieName = paramOrCookieName;
+    }
+
+    public void setDefaultSiteName(String defaultSiteName) {
+        this.defaultSiteName = defaultSiteName;
     }
 
     @Override
@@ -47,8 +52,10 @@ public class CookieSiteResolver implements SiteResolver {
         String siteName = request.getParameter(paramOrCookieName);
         if (StringUtils.isEmpty(siteName)) {
             siteName = HttpUtils.getCookieValue(paramOrCookieName, request);
+            if (StringUtils.isEmpty(siteName))
+                siteName = defaultSiteName;
             if (StringUtils.isEmpty(siteName) && logger.isDebugEnabled()) {
-                logger.debug("No '" + paramOrCookieName + "' request param or cookie found");
+                logger.debug("No '" + paramOrCookieName + "' request param or cookie found. No default sitename set.");
             }
         }
 

--- a/src/main/resources/crafter/engine/mode/multi-tenant/mapped/services-context.xml
+++ b/src/main/resources/crafter/engine/mode/multi-tenant/mapped/services-context.xml
@@ -44,6 +44,7 @@
 
     <bean id="crafter.cookieSiteResolver" class="org.craftercms.engine.service.context.CookieSiteResolver">
         <property name="paramOrCookieName" value="${crafter.engine.request.param.siteName}"/>
+        <property name="defaultSiteName" value="${crafter.engine.site.default.name}"/>
     </bean>
 
     <bean id="crafter.siteResolver" class="org.craftercms.engine.service.context.SiteResolverChain">

--- a/src/main/resources/crafter/engine/mode/multi-tenant/simple/services-context.xml
+++ b/src/main/resources/crafter/engine/mode/multi-tenant/simple/services-context.xml
@@ -44,6 +44,7 @@
 
     <bean id="crafter.siteResolver" class="org.craftercms.engine.service.context.CookieSiteResolver">
         <property name="paramOrCookieName" value="${crafter.engine.request.param.siteName}"/>
+        <property name="defaultSiteName" value="${crafter.engine.site.default.name}"/>
     </bean>
 
     <bean id="crafter.siteContextsBootstrap" class="org.craftercms.engine.service.context.SiteContextsBootstrap">

--- a/src/main/resources/crafter/engine/mode/preview/services-context.xml
+++ b/src/main/resources/crafter/engine/mode/preview/services-context.xml
@@ -47,6 +47,7 @@
 
     <bean id="crafter.siteResolver" class="org.craftercms.engine.service.context.CookieSiteResolver">
         <property name="paramOrCookieName" value="${crafter.engine.request.param.siteName}"/>
+        <property name="defaultSiteName" value="${crafter.engine.site.default.name}"/>
     </bean>
 
     <bean id="crafter.siteContextsBootstrap" class="org.craftercms.engine.service.context.SiteContextsBootstrap">


### PR DESCRIPTION
We have extended the CookieSiteResolver bean to use default sitename from property `crafter.engine.site.default.name` if neither a query parameter is provided nor a cookie value found.

At least in our use-case it is helpful, because sometimes content creator send around preview links (from the authoring instance) to (external) people which don't have access to studio. And, we only have one site in general. The (ugly) query parameter can be omitted.

What do you think? Is that worth sharing?