### PR TITLE
Site context enhancements

### DIFF
--- a/src/main/java/org/craftercms/engine/controller/rest/SiteContentStoreRestController.java
+++ b/src/main/java/org/craftercms/engine/controller/rest/SiteContentStoreRestController.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.craftercms.core.controller.rest.ContentStoreRestController;
 import org.craftercms.core.controller.rest.RestControllerBase;
+import org.craftercms.core.controller.rest.RestControllerBaseWithExceptionHandlers;
 import org.craftercms.core.exception.PathNotFoundException;
 import org.craftercms.engine.service.context.SiteContext;
 import org.springframework.beans.factory.annotation.Required;
@@ -49,7 +50,7 @@ import static org.craftercms.core.controller.rest.ContentStoreRestController.* ;
  */
 @Controller
 @RequestMapping(RestControllerBase.REST_BASE_URI + SiteContentStoreRestController.URL_ROOT)
-public class SiteContentStoreRestController extends RestControllerBase {
+public class SiteContentStoreRestController extends RestControllerBaseWithExceptionHandlers {
 
     public static final String URL_ROOT = "/site/content_store";
 

--- a/src/main/java/org/craftercms/engine/controller/rest/SiteContextRestController.java
+++ b/src/main/java/org/craftercms/engine/controller/rest/SiteContextRestController.java
@@ -24,7 +24,6 @@ import org.craftercms.engine.service.context.SiteContext;
 import org.craftercms.engine.service.context.SiteContextManager;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/org/craftercms/engine/controller/rest/SiteNavigationController.java
+++ b/src/main/java/org/craftercms/engine/controller/rest/SiteNavigationController.java
@@ -20,6 +20,7 @@ package org.craftercms.engine.controller.rest;
 import java.util.List;
 
 import org.craftercms.core.controller.rest.RestControllerBase;
+import org.craftercms.core.controller.rest.RestControllerBaseWithExceptionHandlers;
 import org.craftercms.engine.navigation.NavBreadcrumbBuilder;
 import org.craftercms.engine.navigation.NavItem;
 import org.craftercms.engine.navigation.NavTreeBuilder;
@@ -36,7 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(RestControllerBase.REST_BASE_URI + SiteNavigationController.URL_ROOT)
-public class SiteNavigationController extends RestControllerBase {
+public class SiteNavigationController extends RestControllerBaseWithExceptionHandlers {
 
     public static final String URL_ROOT = "/site/navigation";
     public static final String URL_TREE = "/tree";

--- a/src/main/java/org/craftercms/engine/controller/rest/SiteScheduledJobsController.java
+++ b/src/main/java/org/craftercms/engine/controller/rest/SiteScheduledJobsController.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.craftercms.core.controller.rest.RestControllerBase;
+import org.craftercms.core.controller.rest.RestControllerBaseWithExceptionHandlers;
 import org.craftercms.engine.service.context.SiteContext;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
@@ -41,7 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(RestControllerBase.REST_BASE_URI + SiteScheduledJobsController.URL_ROOT)
-public class SiteScheduledJobsController extends RestControllerBase {
+public class SiteScheduledJobsController extends RestControllerBaseWithExceptionHandlers {
 
     public static final String URL_ROOT = "/site/jobs";
     public static final String URL_LIST = "/list";

--- a/src/main/java/org/craftercms/engine/controller/rest/SiteUrlController.java
+++ b/src/main/java/org/craftercms/engine/controller/rest/SiteUrlController.java
@@ -18,6 +18,7 @@
 package org.craftercms.engine.controller.rest;
 
 import org.craftercms.core.controller.rest.RestControllerBase;
+import org.craftercms.core.controller.rest.RestControllerBaseWithExceptionHandlers;
 import org.craftercms.engine.service.UrlTransformationService;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(RestControllerBase.REST_BASE_URI + SiteUrlController.URL_ROOT)
-public class SiteUrlController extends RestControllerBase {
+public class SiteUrlController extends RestControllerBaseWithExceptionHandlers {
 
     public static final String URL_ROOT = "/site/url";
     public static final String URL_TRANSFORM = "/transform";

--- a/src/main/java/org/craftercms/engine/event/CacheClearedEvent.java
+++ b/src/main/java/org/craftercms/engine/event/CacheClearedEvent.java
@@ -18,21 +18,19 @@ package org.craftercms.engine.event;
 
 import org.craftercms.engine.service.context.SiteContext;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
- * Event published when a new {@link SiteContext} is created.
+ * Event published when a site's cache is cleared.
  *
  * @author avasquez
  */
-public class SiteContextCreatedEvent extends SiteContextEvent {
+public class CacheClearedEvent extends SiteContextEvent {
 
     /**
      * Create a new event.
      *
      * @param siteContext   the site's context
      */
-    public SiteContextCreatedEvent(SiteContext siteContext) {
+    public CacheClearedEvent(SiteContext siteContext) {
         super(siteContext);
     }
 

--- a/src/main/java/org/craftercms/engine/event/GraphQLBuiltEvent.java
+++ b/src/main/java/org/craftercms/engine/event/GraphQLBuiltEvent.java
@@ -18,21 +18,19 @@ package org.craftercms.engine.event;
 
 import org.craftercms.engine.service.context.SiteContext;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
- * Event published when a new {@link SiteContext} is created.
+ * Event published when a site's GraphQL schema is built.
  *
  * @author avasquez
  */
-public class SiteContextCreatedEvent extends SiteContextEvent {
+public class GraphQLBuiltEvent extends SiteContextEvent {
 
     /**
      * Create a new event.
      *
      * @param siteContext   the site's context
      */
-    public SiteContextCreatedEvent(SiteContext siteContext) {
+    public GraphQLBuiltEvent(SiteContext siteContext) {
         super(siteContext);
     }
 

--- a/src/main/java/org/craftercms/engine/event/SiteContextCreatedEvent.java
+++ b/src/main/java/org/craftercms/engine/event/SiteContextCreatedEvent.java
@@ -18,8 +18,6 @@ package org.craftercms.engine.event;
 
 import org.craftercms.engine.service.context.SiteContext;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
  * Event published when a new {@link SiteContext} is created.
  *

--- a/src/main/java/org/craftercms/engine/event/SiteContextDestroyedEvent.java
+++ b/src/main/java/org/craftercms/engine/event/SiteContextDestroyedEvent.java
@@ -17,31 +17,21 @@
 package org.craftercms.engine.event;
 
 import org.craftercms.engine.service.context.SiteContext;
-import org.springframework.context.ApplicationEvent;
 
 /**
  * Event published when a {@link SiteContext} is destroyed.
  *
  * @author avasquez
  */
-public class SiteContextDestroyedEvent extends ApplicationEvent {
-
-    protected SiteContext siteContext;
+public class SiteContextDestroyedEvent extends SiteContextEvent {
 
     /**
      * Create a new event.
      *
-     * @param siteContext   the SiteContext destroyed
-     * @param source        the component that published the event (never {@code null})
+     * @param siteContext   the site's context
      */
-    public SiteContextDestroyedEvent(SiteContext siteContext, Object source) {
-        super(source);
-
-        this.siteContext = siteContext;
-    }
-
-    public SiteContext getSiteContext() {
-        return siteContext;
+    public SiteContextDestroyedEvent(SiteContext siteContext) {
+        super(siteContext);
     }
 
 }

--- a/src/main/java/org/craftercms/engine/event/SiteContextEvent.java
+++ b/src/main/java/org/craftercms/engine/event/SiteContextEvent.java
@@ -17,23 +17,41 @@
 package org.craftercms.engine.event;
 
 import org.craftercms.engine.service.context.SiteContext;
+import org.springframework.context.ApplicationEvent;
 
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * Event published when a new {@link SiteContext} is created.
+ * Application event that is related to a site context.
  *
  * @author avasquez
  */
-public class SiteContextCreatedEvent extends SiteContextEvent {
+public class SiteContextEvent extends ApplicationEvent {
 
     /**
-     * Create a new event.
+     * Returns the latest event of the specified class that has been fired during the handling of the request.
      *
-     * @param siteContext   the site's context
+     * @param eventClass the event class
+     * @param request the request
+     *
+     * @return the latest request event
      */
-    public SiteContextCreatedEvent(SiteContext siteContext) {
+    public static SiteContextEvent getLatestRequestEvent(Class<? extends SiteContextEvent> eventClass,
+                                                         HttpServletRequest request) {
+        return (SiteContextEvent) request.getAttribute(eventClass.getName());
+    }
+
+    /**
+     * Create a new ApplicationEvent.
+     *
+     * @param siteContext the site's context
+     */
+    public SiteContextEvent(SiteContext siteContext) {
         super(siteContext);
+    }
+
+    public SiteContext getSiteContext() {
+        return (SiteContext) getSource();
     }
 
 }

--- a/src/main/java/org/craftercms/engine/scripting/impl/CachedScriptUrlTemplateScanner.java
+++ b/src/main/java/org/craftercms/engine/scripting/impl/CachedScriptUrlTemplateScanner.java
@@ -19,7 +19,6 @@ package org.craftercms.engine.scripting.impl;
 
 import java.util.List;
 
-import org.craftercms.commons.lang.Callback;
 import org.craftercms.core.util.cache.CacheTemplate;
 import org.craftercms.engine.event.SiteContextCreatedEvent;
 import org.craftercms.engine.scripting.ScriptUrlTemplateScanner;
@@ -60,14 +59,8 @@ public class CachedScriptUrlTemplateScanner implements ScriptUrlTemplateScanner,
 
     @Override
     public List<UriTemplate> scan(final SiteContext siteContext) {
-        return cacheTemplate.getObject(siteContext.getContext(), new Callback<List<UriTemplate>>() {
-
-            @Override
-            public List<UriTemplate> execute() {
-                return actualScanner.scan(siteContext);
-            }
-
-        }, URL_TEMPLATES_CACHE_KEY_ELEM);
+        return cacheTemplate.getObject(
+                siteContext.getContext(), () -> actualScanner.scan(siteContext), URL_TEMPLATES_CACHE_KEY_ELEM);
     }
 
 }

--- a/src/main/java/org/craftercms/engine/service/context/SiteContext.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContext.java
@@ -39,7 +39,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfig;
 import org.tuckey.web.filters.urlrewrite.UrlRewriter;
 
-import javax.servlet.http.HttpServletRequest;
 import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/org/craftercms/engine/service/context/SiteContext.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContext.java
@@ -18,11 +18,13 @@ package org.craftercms.engine.service.context;
 
 import graphql.GraphQL;
 import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.craftercms.commons.http.RequestContext;
 import org.craftercms.core.exception.CrafterException;
 import org.craftercms.core.service.CacheService;
 import org.craftercms.core.service.ContentStoreService;
 import org.craftercms.core.service.Context;
 import org.craftercms.core.url.UrlTransformationEngine;
+import org.craftercms.engine.event.*;
 import org.craftercms.engine.exception.GraphQLBuildException;
 import org.craftercms.engine.graphql.GraphQLFactory;
 import org.craftercms.engine.scripting.ScriptFactory;
@@ -37,8 +39,8 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfig;
 import org.tuckey.web.filters.urlrewrite.UrlRewriter;
 
+import javax.servlet.http.HttpServletRequest;
 import java.net.URLClassLoader;
-import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,10 +60,6 @@ public class SiteContext {
 
     private static ThreadLocal<SiteContext> threadLocal = new ThreadLocal<>();
 
-    public static final String CACHE_CLEARED_EVENT_KEY = "cacheCleared";
-    public static final String CONTEXT_BUILT_EVENT_KEY = "contextBuilt";
-    public static final String GRAPHQL_BUILT_EVENT_KEY = "graphQLBuilt";
-
     protected ContentStoreService storeService;
     protected String siteName;
     protected Context context;
@@ -80,7 +78,7 @@ public class SiteContext {
     protected URLClassLoader classLoader;
     protected UrlRewriter urlRewriter;
     protected Scheduler scheduler;
-    protected Map<String, Instant> events;
+    protected Map<Class<? extends SiteContextEvent>, SiteContextEvent> latestEvents;
     protected Lock graphQLBuildLock;
     protected GraphQLFactory graphQLFactory;
     protected GraphQL graphQL;
@@ -112,13 +110,7 @@ public class SiteContext {
 
     public SiteContext() {
         graphQLBuildLock = new ReentrantLock();
-
-        Instant now = Instant.now();
-
-        events = new ConcurrentHashMap<>();
-        events.put(CACHE_CLEARED_EVENT_KEY, now);
-        events.put(CONTEXT_BUILT_EVENT_KEY, now);
-        events.put(GRAPHQL_BUILT_EVENT_KEY, now);
+        latestEvents = new ConcurrentHashMap<>();
     }
 
     public ContentStoreService getStoreService() {
@@ -273,8 +265,12 @@ public class SiteContext {
         this.graphQLFactory = graphQLFactory;
     }
 
-    public Map<String, Instant> getEvents() {
-        return events;
+    public Map<Class<? extends SiteContextEvent>, SiteContextEvent> getLatestEvents() {
+        return latestEvents;
+    }
+
+    public SiteContextEvent getLatestEvent(Class<? extends SiteContextEvent> eventClass) {
+        return latestEvents.get(eventClass);
     }
 
     public GraphQL getGraphQL() {
@@ -285,13 +281,17 @@ public class SiteContext {
         return storeService.validate(context);
     }
 
+    public void init() {
+        publishEvent(new SiteContextCreatedEvent(this));
+    }
+
     public void clearCache(CacheService cacheService) {
         // Clear content cache
         cacheService.clearScope(context);
         // Clear Freemarker cache
         freeMarkerConfig.getConfiguration().clearTemplateCache();
 
-        events.put(CACHE_CLEARED_EVENT_KEY, Instant.now());
+        publishEvent(new CacheClearedEvent(this));
     }
 
     public void buildGraphQLSchema() throws GraphQLBuildException {
@@ -302,7 +302,7 @@ public class SiteContext {
                 if (Objects.nonNull(graphQL)) {
                     this.graphQL = graphQL;
 
-                    events.put(GRAPHQL_BUILT_EVENT_KEY, Instant.now());
+                    publishEvent(new GraphQLBuiltEvent(this));
                 }
             } catch (Exception e) {
                 throw new GraphQLBuildException("Error building the GraphQL schema for site '" + siteName + "'", e);
@@ -316,6 +316,8 @@ public class SiteContext {
     }
 
     public void destroy() throws CrafterException {
+        publishEvent(new SiteContextDestroyedEvent(this));
+
         storeService.destroyContext(context);
 
         if (applicationContext != null) {
@@ -375,6 +377,23 @@ public class SiteContext {
                ", restScriptsPath='" + restScriptsPath + '\'' +
                ", controllerScriptsPath='" + controllerScriptsPath + '\'' +
                '}';
+    }
+
+    protected void publishEvent(SiteContextEvent event) {
+        if (applicationContext != null) {
+            applicationContext.publishEvent(event);
+        } else {
+            globalApplicationContext.publishEvent(event);
+        }
+
+        // Store in the latest events
+        latestEvents.put(event.getClass(), event);
+
+        // Store a request attribute for the event so it's known later if the event was fired during the request
+        RequestContext requestContext = RequestContext.getCurrent();
+        if (requestContext != null) {
+            requestContext.getRequest().setAttribute(event.getClass().getName(), event);
+        }
     }
 
 }

--- a/src/main/java/org/craftercms/engine/service/context/SiteContextManager.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContextManager.java
@@ -24,10 +24,7 @@ import org.craftercms.commons.entitlements.model.EntitlementType;
 import org.craftercms.commons.entitlements.model.Module;
 import org.craftercms.commons.entitlements.validator.EntitlementValidator;
 import org.craftercms.core.exception.RootFolderNotFoundException;
-import org.craftercms.engine.event.SiteContextEvent;
 import org.springframework.beans.factory.annotation.Required;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 
 import javax.annotation.PreDestroy;
 import java.util.Collection;

--- a/src/main/java/org/craftercms/engine/service/context/SiteContextManager.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContextManager.java
@@ -24,12 +24,10 @@ import org.craftercms.commons.entitlements.model.EntitlementType;
 import org.craftercms.commons.entitlements.model.Module;
 import org.craftercms.commons.entitlements.validator.EntitlementValidator;
 import org.craftercms.core.exception.RootFolderNotFoundException;
-import org.craftercms.engine.event.SiteContextCreatedEvent;
-import org.craftercms.engine.event.SiteContextDestroyedEvent;
+import org.craftercms.engine.event.SiteContextEvent;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationEvent;
 
 import javax.annotation.PreDestroy;
 import java.util.Collection;
@@ -45,7 +43,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @author Alfonso Vásquez
  */
-public class SiteContextManager implements ApplicationContextAware {
+public class SiteContextManager {
 
     private static final Log logger = LogFactory.getLog(SiteContextManager.class);
 
@@ -53,7 +51,6 @@ public class SiteContextManager implements ApplicationContextAware {
     protected Map<String, SiteContext> contextRegistry;
     protected SiteContextFactory contextFactory;
     protected SiteContextFactory fallbackContextFactory;
-    protected ApplicationContext applicationContext;
     protected EntitlementValidator entitlementValidator;
     protected Executor jobThreadPoolExecutor;
 
@@ -80,11 +77,6 @@ public class SiteContextManager implements ApplicationContextAware {
     @Required
     public void setJobThreadPoolExecutor(final Executor jobThreadPoolExecutor) {
         this.jobThreadPoolExecutor = jobThreadPoolExecutor;
-    }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext;
     }
 
     @PreDestroy
@@ -308,7 +300,7 @@ public class SiteContextManager implements ApplicationContextAware {
             siteContext = contextFactory.createContext(siteName);
         }
 
-        publishEvent(new SiteContextCreatedEvent(siteContext, this), siteContext);
+        siteContext.init();
 
         contextRegistry.put(siteName, siteContext);
 
@@ -320,20 +312,9 @@ public class SiteContextManager implements ApplicationContextAware {
     }
 
     protected void destroyContext(SiteContext siteContext) {
-        publishEvent(new SiteContextDestroyedEvent(siteContext, this), siteContext);
-
         siteContext.destroy();
 
         logger.info("Site context destroyed: " + siteContext);
-    }
-
-    protected void publishEvent(ApplicationEvent event, SiteContext siteContext) {
-        ApplicationContext siteApplicationContext = siteContext.getApplicationContext();
-        if (siteApplicationContext != null) {
-            siteApplicationContext.publishEvent(event);
-        } else {
-            applicationContext.publishEvent(event);
-        }
     }
 
     protected boolean validateSiteCreationEntitlement() {


### PR DESCRIPTION
* Site context events are not actually `ApplicationEvents` that are fired and can be listened to.
* Site context rebuild methods now check first if the context was build earlier so the context/schema are not built twice.

Ticket craftercms/craftercms#3151
