### PR TITLE
The preloaded folders list is now stored in cache

### DIFF
--- a/src/main/java/org/craftercms/engine/cache/CacheWarmingAwareContentStoreAdapterDecorator.java
+++ b/src/main/java/org/craftercms/engine/cache/CacheWarmingAwareContentStoreAdapterDecorator.java
@@ -17,10 +17,7 @@
 package org.craftercms.engine.cache;
 
 import org.craftercms.core.exception.*;
-import org.craftercms.core.service.CachingOptions;
-import org.craftercms.core.service.Content;
-import org.craftercms.core.service.Context;
-import org.craftercms.core.service.Item;
+import org.craftercms.core.service.*;
 import org.craftercms.core.store.ContentStoreAdapter;
 import org.craftercms.core.util.ContentStoreUtils;
 import org.craftercms.engine.util.store.decorators.ContentStoreAdapterDecorator;
@@ -44,6 +41,7 @@ public class CacheWarmingAwareContentStoreAdapterDecorator implements ContentSto
 
     protected boolean warmUpEnabled;
     protected ContentStoreAdapter actualStoreAdapter;
+    protected CacheService cacheService;
 
     @Required
     public void setWarmUpEnabled(boolean warmUpEnabled) {
@@ -55,6 +53,11 @@ public class CacheWarmingAwareContentStoreAdapterDecorator implements ContentSto
         this.actualStoreAdapter = actualStoreAdapter;
     }
 
+    @Required
+    public void setCacheService(CacheService cacheService) {
+        this.cacheService = cacheService;
+    }
+
     @Override
     public Context createContext(String id, String rootFolderPath, boolean mergingOn, boolean cacheOn,
                                  int maxAllowedItemsInCache, boolean ignoreHiddenFiles)
@@ -62,7 +65,7 @@ public class CacheWarmingAwareContentStoreAdapterDecorator implements ContentSto
         Context context = actualStoreAdapter.createContext(id, rootFolderPath, mergingOn, cacheOn,
                                                            maxAllowedItemsInCache, ignoreHiddenFiles);
         if (warmUpEnabled) {
-            return new PreloadedFoldersAwareContext(context, actualStoreAdapter);
+            return new PreloadedFoldersAwareContext(context, actualStoreAdapter, cacheService);
         } else {
             return context;
         }

--- a/src/main/java/org/craftercms/engine/cache/PreloadedFoldersAwareContext.java
+++ b/src/main/java/org/craftercms/engine/cache/PreloadedFoldersAwareContext.java
@@ -16,6 +16,7 @@
  */
 package org.craftercms.engine.cache;
 
+import org.craftercms.core.service.CacheService;
 import org.craftercms.core.service.Context;
 import org.craftercms.core.store.ContentStoreAdapter;
 import org.craftercms.engine.util.store.decorators.DecoratedStoreAdapterContext;
@@ -32,30 +33,33 @@ import java.util.List;
  */
 class PreloadedFoldersAwareContext extends DecoratedStoreAdapterContext {
 
-    protected List<PreloadedFolder> preloadedFolders;
+    public static final String PRELOADED_FOLDERS_CACHE_KEY = "cache.warmUp.preloadedFolders";
 
-    public PreloadedFoldersAwareContext(Context actualContext, ContentStoreAdapter decoratedStoreAdapter) {
-        super(actualContext, decoratedStoreAdapter);
-        this.preloadedFolders = Collections.emptyList();
-    }
+    protected CacheService cacheService;
 
     public PreloadedFoldersAwareContext(Context actualContext, ContentStoreAdapter decoratedStoreAdapter,
-                                        List<PreloadedFolder> preloadedFolders) {
+                                        CacheService cacheService) {
         super(actualContext, decoratedStoreAdapter);
-        this.preloadedFolders = preloadedFolders;
+        this.cacheService = cacheService;
     }
 
+    @SuppressWarnings("unchecked")
     public List<PreloadedFolder> getPreloadedFolders() {
-        return preloadedFolders;
+        List<PreloadedFolder> folders = (List<PreloadedFolder>) cacheService.get(this, PRELOADED_FOLDERS_CACHE_KEY);
+        if (folders != null) {
+            return folders;
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     public void setPreloadedFolders(List<PreloadedFolder> preloadedFolders) {
-        this.preloadedFolders = preloadedFolders;
+        cacheService.put(this, PRELOADED_FOLDERS_CACHE_KEY, preloadedFolders);
     }
 
     @Override
     public Context clone() {
-        return new PreloadedFoldersAwareContext(actualContext.clone(), decoratedStoreAdapter, preloadedFolders);
+        return new PreloadedFoldersAwareContext(actualContext.clone(), decoratedStoreAdapter, cacheService);
     }
 
 }

--- a/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -387,6 +387,7 @@
     <bean id="crafter.cacheWarmingContentStoreAdapterDecorator"
           class="org.craftercms.engine.cache.CacheWarmingAwareContentStoreAdapterDecorator" scope="prototype">
         <property name="warmUpEnabled" value="${crafter.engine.site.cache.warmUp.enabled}"/>
+        <property name="cacheService" ref="crafter.cacheService"/>
     </bean>
 
     <bean id="crafter.contentStoreAdapterPreloadedFoldersBasedCacheWarmer"


### PR DESCRIPTION
The preloaded folders list is now stored in cache instead of the context itself. This now allows to have a fresh list of preloaded folders every time the cache is warmed up.

Ticket craftercms/craftercms#3695
