### PR TITLE
Groovy and Freemarker cache enhancements:

### DIFF
--- a/src/main/java/org/craftercms/engine/freemarker/CrafterFreeMarkerConfigurer.java
+++ b/src/main/java/org/craftercms/engine/freemarker/CrafterFreeMarkerConfigurer.java
@@ -16,17 +16,20 @@
  */
 package org.craftercms.engine.freemarker;
 
-import java.io.IOException;
-import java.util.List;
-
 import freemarker.cache.CacheStorage;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.cache.TemplateLoader;
-import freemarker.template.Configuration;
-import freemarker.template.TemplateException;
-import freemarker.template.TemplateExceptionHandler;
+import freemarker.template.*;
+import org.craftercms.core.exception.CrafterException;
+import org.craftercms.core.util.cache.CacheTemplate;
 import org.craftercms.engine.macro.MacroResolver;
+import org.craftercms.engine.service.context.SiteContext;
+import org.springframework.beans.factory.annotation.Required;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Extends {@link org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer} to:
@@ -39,9 +42,12 @@ import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
  */
 public class CrafterFreeMarkerConfigurer extends FreeMarkerConfigurer {
 
+    public static final String CACHE_CONST_KEY_ELEM_TEMPLATE = "freemarkerTemplate";
+
     private MacroResolver macroResolver;
     private TemplateExceptionHandler templateExceptionHandler;
-    private CacheStorage cacheStorage;
+    private CacheStorage freemarkerCacheStorage;
+    private CacheTemplate cacheTemplate;
 
     public void setMacroResolver(MacroResolver macroResolver) {
         this.macroResolver = macroResolver;
@@ -51,8 +57,18 @@ public class CrafterFreeMarkerConfigurer extends FreeMarkerConfigurer {
         this.templateExceptionHandler = templateExceptionHandler;
     }
 
-    public void setCacheStorage(final CacheStorage cacheStorage) {
-        this.cacheStorage = cacheStorage;
+    public void setFreemarkerCacheStorage(final CacheStorage freemarkerCacheStorage) {
+        this.freemarkerCacheStorage = freemarkerCacheStorage;
+    }
+
+    @Required
+    public void setCacheTemplate(CacheTemplate cacheTemplate) {
+        this.cacheTemplate = cacheTemplate;
+    }
+
+    @Override
+    protected Configuration newConfiguration() throws IOException, TemplateException {
+        return new CrafterCacheAwareConfiguration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
     }
 
     @Override
@@ -60,8 +76,8 @@ public class CrafterFreeMarkerConfigurer extends FreeMarkerConfigurer {
         if (templateExceptionHandler != null) {
             config.setTemplateExceptionHandler(templateExceptionHandler);
         }
-        if (cacheStorage != null) {
-            config.setCacheStorage(cacheStorage);
+        if (freemarkerCacheStorage != null) {
+            config.setCacheStorage(freemarkerCacheStorage);
         }
     }
 
@@ -78,6 +94,39 @@ public class CrafterFreeMarkerConfigurer extends FreeMarkerConfigurer {
     protected void postProcessTemplateLoaders(List<TemplateLoader> templateLoaders) {
         // Overwrote to get rid of the log.info
         templateLoaders.add(new ClassTemplateLoader(FreeMarkerConfigurer.class, ""));
+    }
+
+    /**
+     * Freemarker {@code Configuration} class extension that caches the template in the Crafter Cache, allowing for
+     * templates to be loaded and parsed once, even when concurrent threads are trying to retrieve the same template.
+     */
+    public class CrafterCacheAwareConfiguration extends Configuration {
+
+        public CrafterCacheAwareConfiguration(Version incompatibleImprovements) {
+            super(incompatibleImprovements);
+        }
+
+        @Override
+        public Template getTemplate(String name, Locale locale, Object customLookupCondition, String encoding,
+                                    boolean parseAsFTL, boolean ignoreMissing) throws IOException {
+            SiteContext siteContext = SiteContext.getCurrent();
+            if (siteContext != null) {
+                try {
+                    return cacheTemplate.getObject(siteContext.getContext(), () -> {
+                        try {
+                            return super.getTemplate(name, locale, customLookupCondition, encoding, parseAsFTL,
+                                                     ignoreMissing);
+                        } catch (Exception e) {
+                            throw new CrafterException(e);
+                        }
+                    }, name, locale, customLookupCondition, encoding, parseAsFTL, CACHE_CONST_KEY_ELEM_TEMPLATE);
+                } catch (CrafterException e) {
+                    throw (IOException) e.getCause();
+                }
+            } else {
+                return super.getTemplate(name, locale, customLookupCondition, encoding, parseAsFTL, ignoreMissing);
+            }
+        }
     }
 
 }

--- a/src/main/java/org/craftercms/engine/graphql/impl/GraphQLFactoryImpl.java
+++ b/src/main/java/org/craftercms/engine/graphql/impl/GraphQLFactoryImpl.java
@@ -17,17 +17,6 @@
 
 package org.craftercms.engine.graphql.impl;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.Executor;
-
-import javax.servlet.ServletContext;
-
 import graphql.GraphQL;
 import graphql.schema.*;
 import org.apache.commons.collections.CollectionUtils;
@@ -37,7 +26,6 @@ import org.craftercms.core.service.Tree;
 import org.craftercms.engine.exception.ScriptNotFoundException;
 import org.craftercms.engine.graphql.GraphQLFactory;
 import org.craftercms.engine.graphql.GraphQLTypeFactory;
-import org.craftercms.engine.scripting.Script;
 import org.craftercms.engine.service.context.SiteContext;
 import org.craftercms.engine.util.GroovyScriptUtils;
 import org.craftercms.engine.util.concurrent.SiteAwareThreadPoolExecutor;
@@ -46,6 +34,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.util.StopWatch;
 import org.springframework.web.context.ServletContextAware;
+
+import javax.servlet.ServletContext;
+import java.util.*;
+import java.util.concurrent.Executor;
 
 import static graphql.schema.AsyncDataFetcher.async;
 import static graphql.schema.FieldCoordinates.coordinates;
@@ -243,14 +235,12 @@ public class GraphQLFactoryImpl implements GraphQLFactory, ServletContextAware {
     protected void runInitScript(SiteContext siteContext, GraphQLObjectType.Builder rootType,
                                  GraphQLCodeRegistry.Builder codeRegistry, SchemaCustomizer customizer,
                                  Map<String, GraphQLObjectType.Builder> siteTypes) {
-        Script script = siteContext.getScriptFactory().getScript(schemaScriptPath);
-
         Map<String, Object> variables = new HashMap<>();
         GroovyScriptUtils.addJobScriptVariables(variables, servletContext);
         variables.put(VARIABLE_SCHEMA, customizer);
 
         try {
-            script.execute(variables);
+            siteContext.getScriptFactory().getScript(schemaScriptPath).execute(variables);
             logger.info("Updating GraphQL schema with custom fields, fetchers & resolvers");
             customizer.apply(rootQueryTypeName, rootType, codeRegistry, siteTypes);
         } catch (ScriptNotFoundException e) {

--- a/src/main/java/org/craftercms/engine/service/context/SiteContextFactory.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContextFactory.java
@@ -26,10 +26,11 @@ import org.apache.commons.logging.LogFactory;
 import org.craftercms.commons.crypto.TextEncryptor;
 import org.craftercms.commons.crypto.impl.NoOpTextEncryptor;
 import org.craftercms.commons.spring.ApacheCommonsConfiguration2PropertySource;
-import org.craftercms.core.service.CacheService;
 import org.craftercms.core.service.ContentStoreService;
 import org.craftercms.core.service.Context;
 import org.craftercms.core.url.UrlTransformationEngine;
+import org.craftercms.core.util.cache.CacheTemplate;
+import org.craftercms.engine.cache.SiteCacheWarmer;
 import org.craftercms.engine.exception.SiteContextCreationException;
 import org.craftercms.engine.graphql.GraphQLFactory;
 import org.craftercms.engine.macro.MacroResolver;
@@ -37,7 +38,6 @@ import org.craftercms.engine.scripting.ScriptFactory;
 import org.craftercms.engine.scripting.ScriptJobResolver;
 import org.craftercms.engine.scripting.impl.GroovyScriptFactory;
 import org.craftercms.engine.util.SchedulingUtils;
-import org.craftercms.engine.cache.SiteCacheWarmer;
 import org.craftercms.engine.util.config.impl.MultiResourceConfigurationBuilder;
 import org.craftercms.engine.util.groovy.ContentStoreGroovyResourceLoader;
 import org.craftercms.engine.util.groovy.ContentStoreResourceConnector;
@@ -101,7 +101,7 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
     protected ObjectFactory<FreeMarkerConfig> freeMarkerConfigFactory;
     protected UrlTransformationEngine urlTransformationEngine;
     protected ContentStoreService storeService;
-    protected CacheService cacheService;
+    protected CacheTemplate cacheTemplate;
     protected MacroResolver macroResolver;
     protected ApplicationContext globalApplicationContext;
     protected List<ScriptJobResolver> jobResolvers;
@@ -220,8 +220,8 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
     }
 
     @Required
-    public void setCacheService(CacheService cacheService) {
-        this.cacheService = cacheService;
+    public void setCacheTemplate(CacheTemplate cacheTemplate) {
+        this.cacheTemplate = cacheTemplate;
     }
 
     @Required
@@ -274,7 +274,7 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
         try {
             SiteContext siteContext = new SiteContext();
             siteContext.setStoreService(storeService);
-            siteContext.setCacheService(cacheService);
+            siteContext.setCacheService(cacheTemplate.getCacheService());
             siteContext.setSiteName(siteName);
             siteContext.setContext(context);
             siteContext.setStaticAssetsPath(staticAssetsPath);
@@ -482,7 +482,8 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
     }
 
     protected ScriptFactory getScriptFactory(SiteContext siteContext, URLClassLoader classLoader) {
-        return new GroovyScriptFactory(new ContentStoreResourceConnector(siteContext), classLoader, groovyGlobalVars);
+        return new GroovyScriptFactory(siteContext, cacheTemplate, new ContentStoreResourceConnector(siteContext),
+                                       classLoader, groovyGlobalVars);
     }
 
     protected Scheduler scheduleJobs(SiteContext siteContext) {

--- a/src/main/java/org/craftercms/engine/view/CrafterPageView.java
+++ b/src/main/java/org/craftercms/engine/view/CrafterPageView.java
@@ -16,13 +16,6 @@
  */
 package org.craftercms.engine.view;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -42,6 +35,13 @@ import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.view.AbstractView;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
 /**
  * @author Alfonso Vásquez
  */
@@ -60,7 +60,6 @@ public class CrafterPageView extends AbstractView implements CachingAwareObject,
 
     protected transient String scope;
     protected transient Object key;
-    protected transient List<Object> dependencyKeys;
     protected transient Long cachingTime;
 
     protected SiteItem page;

--- a/src/main/resources/crafter/engine/mode/preview/services-context.xml
+++ b/src/main/resources/crafter/engine/mode/preview/services-context.xml
@@ -74,7 +74,7 @@
         <property name="cacheOn" value="false"/>
         <property name="urlTransformationEngine" ref="crafter.urlTransformationEngine"/>
         <property name="storeService" ref="crafter.contentStoreService"/>
-        <property name="cacheService" ref="crafter.cacheService"/>
+        <property name="cacheTemplate" ref="crafter.cacheTemplate"/>
         <property name="macroResolver" ref="crafter.macroResolver"/>
         <property name="groovyGlobalVars" ref="crafter.restScriptsVariables"/>
         <property name="jobResolvers" ref="crafter.scriptJobResolvers"/>
@@ -135,9 +135,10 @@
                 <ref bean="crafter.crafterFreeMarkerTemplateLoader"/>
             </array>
         </property>
-        <property name="cacheStorage">
+        <property name="freemarkerCacheStorage">
             <bean class="freemarker.cache.NullCacheStorage"/>
         </property>
+        <property name="cacheTemplate" ref="crafter.cacheTemplate"/>
     </bean>
 
 </beans>

--- a/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -490,7 +490,7 @@
         <property name="groovyClassesPath" value="${crafter.engine.site.default.classes.groovy.path}"/>
         <property name="urlTransformationEngine" ref="crafter.urlTransformationEngine"/>
         <property name="storeService" ref="crafter.contentStoreService"/>
-        <property name="cacheService" ref="crafter.cacheService"/>
+        <property name="cacheTemplate" ref="crafter.cacheTemplate"/>
         <property name="macroResolver" ref="crafter.macroResolver"/>
         <property name="groovyGlobalVars" ref="crafter.restScriptsVariables"/>
         <property name="jobResolvers" ref="crafter.scriptJobResolvers"/>
@@ -517,7 +517,7 @@
         <property name="groovyClassesPath" value="/classes/groovy"/>
         <property name="urlTransformationEngine" ref="crafter.urlTransformationEngine"/>
         <property name="storeService" ref="crafter.contentStoreService"/>
-        <property name="cacheService" ref="crafter.cacheService"/>
+        <property name="cacheTemplate" ref="crafter.cacheTemplate"/>
         <property name="macroResolver" ref="crafter.macroResolver"/>
         <property name="groovyGlobalVars" ref="crafter.restScriptsVariables"/>
         <property name="jobResolvers" ref="crafter.scriptJobResolvers"/>
@@ -616,6 +616,7 @@
                 <ref bean="crafter.crafterFreeMarkerTemplateLoader"/>
             </array>
         </property>
+        <property name="cacheTemplate" ref="crafter.cacheTemplate"/>
     </bean>
 
     <util:map id="crafter.freemarkerVariables">

--- a/src/test/java/org/craftercms/engine/scripting/impl/GroovyScriptFactoryTest.java
+++ b/src/test/java/org/craftercms/engine/scripting/impl/GroovyScriptFactoryTest.java
@@ -17,18 +17,14 @@
 
 package org.craftercms.engine.scripting.impl;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-
 import groovy.lang.GroovyClassLoader;
-import groovy.util.GroovyScriptEngine;
 import org.craftercms.commons.http.RequestContext;
 import org.craftercms.core.service.ContentStoreService;
 import org.craftercms.core.service.Context;
+import org.craftercms.core.util.cache.CacheTemplate;
 import org.craftercms.engine.scripting.ScriptFactory;
 import org.craftercms.engine.service.context.SiteContext;
+import org.craftercms.engine.test.utils.CacheTemplateMockUtils;
 import org.craftercms.engine.test.utils.ContentStoreServiceMockUtils;
 import org.craftercms.engine.util.groovy.ContentStoreGroovyResourceLoader;
 import org.craftercms.engine.util.groovy.ContentStoreResourceConnector;
@@ -39,6 +35,11 @@ import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockHttpServletRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -101,6 +102,13 @@ public class GroovyScriptFactoryTest {
         return storeService;
     }
 
+    private CacheTemplate createCacheTemplate() {
+        CacheTemplate cacheTemplate = mock(CacheTemplate.class);
+        CacheTemplateMockUtils.setUpWithNoCaching(cacheTemplate);
+
+        return cacheTemplate;
+    }
+
     private GroovyClassLoader createGroovyClassLoader() {
         ContentStoreGroovyResourceLoader resourceLoader = new ContentStoreGroovyResourceLoader(SiteContext.getCurrent(),
                                                                                                "/classes");
@@ -128,8 +136,10 @@ public class GroovyScriptFactoryTest {
 
     private ScriptFactory createScriptFactory(GroovyClassLoader parentClassLoader, Map<String, Object> globalVars) {
         ContentStoreResourceConnector resourceConnector = new ContentStoreResourceConnector(SiteContext.getCurrent());
+        CacheTemplate cacheTemplate = createCacheTemplate();
 
-        return new GroovyScriptFactory(resourceConnector, parentClassLoader, globalVars);
+        return new GroovyScriptFactory(SiteContext.getCurrent(), cacheTemplate, resourceConnector, parentClassLoader,
+                                       globalVars);
     }
 
     private void setCurrentSiteContext(SiteContext siteContext) {

--- a/src/test/java/org/craftercms/engine/scripting/impl/ScriptFilterTest.java
+++ b/src/test/java/org/craftercms/engine/scripting/impl/ScriptFilterTest.java
@@ -17,14 +17,6 @@
 
 package org.craftercms.engine.scripting.impl;
 
-import java.util.Collections;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import groovy.util.GroovyScriptEngine;
 import org.apache.commons.configuration2.XMLConfiguration;
 import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
 import org.craftercms.commons.http.RequestContext;
@@ -46,7 +38,15 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 
-import static org.junit.Assert.*;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -73,7 +73,7 @@ public class ScriptFilterTest {
         CacheTemplateMockUtils.setUpWithNoCaching(cacheTemplate);
         ContentStoreServiceMockUtils.setUpGetContentFromClassPath(storeService);
 
-        siteContext = createSiteContext(storeService);
+        siteContext = createSiteContext(storeService, cacheTemplate);
         servletContext = new MockServletContext();
 
         filter = new ScriptFilter();
@@ -129,9 +129,9 @@ public class ScriptFilterTest {
         clearCurrentRequestContext();
     }
 
-    private SiteContext createSiteContext(ContentStoreService storeService) throws Exception {
+    private SiteContext createSiteContext(ContentStoreService storeService, CacheTemplate cacheTemplate) throws Exception {
         SiteContext siteContext = mock(SiteContext.class);
-        ScriptFactory scriptFactory = createScriptFactory(siteContext);
+        ScriptFactory scriptFactory = createScriptFactory(siteContext, cacheTemplate);
 
         XMLConfiguration config = ConfigUtils.readXmlConfiguration(new ClassPathResource("config/site-config.xml"), ',');
         config.setListDelimiterHandler(new DefaultListDelimiterHandler(','));
@@ -145,10 +145,10 @@ public class ScriptFilterTest {
         return siteContext;
     }
 
-    private ScriptFactory createScriptFactory(SiteContext siteContext) {
+    private ScriptFactory createScriptFactory(SiteContext siteContext, CacheTemplate cacheTemplate) {
         ContentStoreResourceConnector resourceConnector = new ContentStoreResourceConnector(siteContext);
 
-        return new GroovyScriptFactory(resourceConnector, Collections.emptyMap());
+        return new GroovyScriptFactory(siteContext, cacheTemplate, resourceConnector, Collections.emptyMap());
     }
 
     private void setCurrentRequestContext(HttpServletRequest request, HttpServletResponse response) {

--- a/src/test/java/org/craftercms/engine/test/utils/CacheTemplateMockUtils.java
+++ b/src/test/java/org/craftercms/engine/test/utils/CacheTemplateMockUtils.java
@@ -21,12 +21,8 @@ import org.craftercms.commons.lang.Callback;
 import org.craftercms.core.service.CachingOptions;
 import org.craftercms.core.service.Context;
 import org.craftercms.core.util.cache.CacheTemplate;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyVararg;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Test utils for mocking a {@link CacheTemplate}.
@@ -35,33 +31,22 @@ import static org.mockito.Mockito.when;
  */
 public class CacheTemplateMockUtils {
 
-    public static CacheTemplate setUpWithNoCaching(CacheTemplate mock) {
-        when(mock.getObject(any(Context.class), any(Callback.class), anyVararg())).then(new Answer<Object>() {
+    @SuppressWarnings("unchecked")
+    public static void setUpWithNoCaching(CacheTemplate mock) {
+        when(mock.getObject(any(Context.class), any(Callback.class), anyVararg())).then(invocation -> {
+            Object[] args = invocation.getArguments();
+            Callback<?> callback = (Callback<?>) args[1];
 
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                Callback<?> callback = (Callback<?>) args[1];
-
-                return callback.execute();
-            }
-
+            return callback.execute();
         });
         when(mock.getObject(any(Context.class), any(CachingOptions.class), any(Callback.class), anyVararg())).then(
-            new Answer<Object>() {
-
-                @Override
-                public Object answer(InvocationOnMock invocation) throws Throwable {
+                invocation -> {
                     Object[] args = invocation.getArguments();
                     Callback<?> callback = (Callback<?>) args[2];
 
                     return callback.execute();
                 }
-
-            }
         );
-
-        return mock;
     }
 
 }

--- a/src/test/java/org/craftercms/engine/util/groovy/Dom4jExtensionTest.java
+++ b/src/test/java/org/craftercms/engine/util/groovy/Dom4jExtensionTest.java
@@ -17,23 +17,25 @@
 
 package org.craftercms.engine.util.groovy;
 
-import java.io.StringReader;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import groovy.util.GroovyScriptEngine;
 import org.craftercms.core.service.ContentStoreService;
+import org.craftercms.core.util.cache.CacheTemplate;
 import org.craftercms.engine.scripting.ScriptFactory;
 import org.craftercms.engine.scripting.impl.GroovyScriptFactory;
 import org.craftercms.engine.service.context.SiteContext;
+import org.craftercms.engine.test.utils.CacheTemplateMockUtils;
 import org.craftercms.engine.test.utils.ContentStoreServiceMockUtils;
 import org.dom4j.io.SAXReader;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by alfonsovasquez on 1/8/16.
@@ -52,10 +54,11 @@ public class Dom4jExtensionTest {
 
     @Before
     public void setUp() throws Exception {
+        CacheTemplate cacheTemplate = createCacheTemplate();
         SiteContext siteContext = createSiteContext(createContentStoreService());
         Map<String, Object> globalVars = Collections.emptyMap();
 
-        scriptFactory = createScriptFactory(siteContext, globalVars);
+        scriptFactory = createScriptFactory(siteContext, cacheTemplate, globalVars);
     }
 
     @Test
@@ -79,6 +82,13 @@ public class Dom4jExtensionTest {
         return storeService;
     }
 
+    private CacheTemplate createCacheTemplate() {
+        CacheTemplate cacheTemplate = mock(CacheTemplate.class);
+        CacheTemplateMockUtils.setUpWithNoCaching(cacheTemplate);
+
+        return cacheTemplate;
+    }
+
     private SiteContext createSiteContext(ContentStoreService storeService) {
         SiteContext siteContext = mock(SiteContext.class);
         when(siteContext.getSiteName()).thenReturn("default");
@@ -87,10 +97,11 @@ public class Dom4jExtensionTest {
         return siteContext;
     }
 
-    private ScriptFactory createScriptFactory(SiteContext siteContext, Map<String, Object> globalVars) {
+    private ScriptFactory createScriptFactory(SiteContext siteContext, CacheTemplate cacheTemplate,
+                                              Map<String, Object> globalVars) {
         ContentStoreResourceConnector resourceConnector = new ContentStoreResourceConnector(siteContext);
 
-        return new GroovyScriptFactory(resourceConnector, globalVars);
+        return new GroovyScriptFactory(siteContext, cacheTemplate, resourceConnector, globalVars);
     }
 
 }


### PR DESCRIPTION
- Groovy scripts and Freemarker templates are now cached in the Crafter Cache with double-checked locking to prevent concurrent threads from compiling the same scripts/templates multiple times.
