### PR TITLE
Fix GraphQL issue:

### DIFF
--- a/src/main/java/org/craftercms/engine/graphql/impl/SchemaCustomizer.java
+++ b/src/main/java/org/craftercms/engine/graphql/impl/SchemaCustomizer.java
@@ -32,6 +32,7 @@ import graphql.schema.GraphQLType;
 import graphql.schema.StaticDataFetcher;
 import graphql.schema.TypeResolver;
 import org.apache.commons.lang3.StringUtils;
+import org.craftercms.engine.graphql.impl.fetchers.ConverterDataFetcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,7 +151,7 @@ public class SchemaCustomizer {
                         String.format("GraphQL schema already contains a field '%s'", fieldName));
                 }
                 rootTypeBuilder.field(builder.field);
-                codeRegistry.dataFetcher(coordinates(rootTypeName, fieldName), builder.fetcher);
+                codeRegistry.dataFetcher(coordinates(rootTypeName, fieldName), ConverterDataFetcher.of(builder.fetcher));
             } else {
                 // Add a field to a specific type
                 if (!types.containsKey(builder.typeName)) {
@@ -162,14 +163,16 @@ public class SchemaCustomizer {
                 }
                 logger.debug("Adding custom field & fetcher {}.{}", builder.typeName, fieldName);
                 types.get(builder.typeName).field(builder.field);
-                codeRegistry.dataFetcher(coordinates(builder.typeName, fieldName), builder.fetcher);
+                codeRegistry.dataFetcher(coordinates(builder.typeName, fieldName),
+                        ConverterDataFetcher.of(builder.fetcher));
             }
 
         });
 
         fetchers.forEach(builder -> {
             logger.debug("Adding custom fetcher for {}/{}", builder.typeName, builder.fieldName);
-            codeRegistry.dataFetcher(coordinates(builder.typeName, builder.fieldName), builder.dataFetcher);
+            codeRegistry.dataFetcher(coordinates(builder.typeName, builder.fieldName),
+                    ConverterDataFetcher.of(builder.dataFetcher));
         });
         resolvers.forEach(builder -> {
             logger.debug("Adding custom resolver for {}", builder.typeName);

--- a/src/main/java/org/craftercms/engine/graphql/impl/fetchers/ConverterDataFetcher.java
+++ b/src/main/java/org/craftercms/engine/graphql/impl/fetchers/ConverterDataFetcher.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2007-2020 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.graphql.impl.fetchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.Map;
+
+/**
+ * Implementation of {@link DataFetcher} to converts the result to {@link Map}.
+ *
+ * This is a workaround because the {@link graphql.schema.PropertyDataFetcher} has an internal cache for methods that
+ * causes a conflict when Groovy classes are reloaded and at the moment is not possible to change the DataFetcher used.
+ *
+ * @author joseross
+ * @since 3.1.6
+ */
+public class ConverterDataFetcher implements DataFetcher<Object> {
+
+    public static ConverterDataFetcher of(DataFetcher<?> dataFetcher) {
+        return new ConverterDataFetcher(dataFetcher);
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
+
+    protected DataFetcher<?> dataFetcher;
+
+    public ConverterDataFetcher(DataFetcher<?> dataFetcher) {
+        this.dataFetcher = dataFetcher;
+    }
+
+    @Override
+    public Object get(DataFetchingEnvironment environment) throws Exception {
+        Object source = dataFetcher.get(environment);
+        if (source != null) {
+            return MAPPER.convertValue(source, Object.class);
+        } else {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
- Groovy objects are always converted to Map to avoid GraphQL cache issues

https://github.com/craftercms/craftercms/issues/3860