### PR TITLE
Improvement for site context rebuild:

### DIFF
--- a/src/main/java/org/craftercms/engine/service/context/SiteContext.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContext.java
@@ -48,6 +48,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Wrapper for a {@link Context} that adds properties specific to Crafter Engine.
@@ -100,6 +103,11 @@ public class SiteContext {
 
     private ServletContext servletContext;
 
+    private long shutdownTimeout;
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final Lock readLock = readWriteLock.readLock();
+    private final Lock writeLock = readWriteLock.writeLock();
+
     /**
      * Returns the context for the current thread.
      */
@@ -129,6 +137,9 @@ public class SiteContext {
      * Sets the context for the current thread.
      */
     public static void setCurrent(SiteContext current) {
+        logger.debug("Getting read lock for context {}", current);
+        current.readLock.lock();
+
         threadLocal.set(current);
 
         MDC.put(SITE_NAME_MDC_KEY, current.getSiteName());
@@ -139,6 +150,10 @@ public class SiteContext {
      */
     public static void clear() {
         MDC.remove(SITE_NAME_MDC_KEY);
+
+        SiteContext current = threadLocal.get();
+        logger.debug("Releasing read lock for context {}", current);
+        current.readLock.unlock();
 
         threadLocal.remove();
     }
@@ -328,6 +343,10 @@ public class SiteContext {
         this.initTimeout = initTimeout;
     }
 
+    public void setShutdownTimeout(long shutdownTimeout) {
+        this.shutdownTimeout = shutdownTimeout;
+    }
+
     public GraphQL getGraphQL() {
         return graphQL;
     }
@@ -425,34 +444,51 @@ public class SiteContext {
     }
 
     public void destroy() throws CrafterException {
-        state = State.DESTROYED;
+        boolean locked;
+        try {
+            logger.debug("Getting write lock for context {}", this);
+            locked = writeLock.tryLock(shutdownTimeout, TimeUnit.MINUTES);
 
-        publishEvent(new SiteContextDestroyedEvent(this));
-
-        maintenanceTaskExecutor.shutdownNow();
-
-        storeService.destroyContext(context);
-
-        if (applicationContext != null) {
-            try {
-                applicationContext.close();
-            } catch (Exception e) {
-                throw new CrafterException("Unable to close application context", e);
+            if (!locked) {
+                logger.debug("Time out reached, proceeding to destroy context {}", this);
+            } else {
+                logger.debug("All threads released, proceeding to destroy context {}", this);
             }
-        }
-        if (classLoader != null) {
-            try {
-                classLoader.close();
-            } catch (Exception e) {
-                throw new CrafterException("Unable to close class loader", e);
+
+            state = State.DESTROYED;
+
+            publishEvent(new SiteContextDestroyedEvent(this));
+
+            maintenanceTaskExecutor.shutdownNow();
+
+            storeService.destroyContext(context);
+
+            if (scheduler != null) {
+                try {
+                    scheduler.shutdown();
+                } catch (SchedulerException e) {
+                    throw new CrafterException("Unable to shutdown scheduler", e);
+                }
             }
-        }
-        if (scheduler != null) {
-            try {
-                scheduler.shutdown();
-            } catch (SchedulerException e) {
-                throw new CrafterException("Unable to shutdown scheduler", e);
+            if (applicationContext != null) {
+                try {
+                    applicationContext.close();
+                } catch (Exception e) {
+                    throw new CrafterException("Unable to close application context", e);
+                }
             }
+            if (classLoader != null) {
+                try {
+                    classLoader.close();
+                } catch (Exception e) {
+                    throw new CrafterException("Unable to close class loader", e);
+                }
+            }
+        } catch (InterruptedException e) {
+            throw new CrafterException("Unable to destroy context", e);
+        } finally {
+            logger.debug("Releasing write lock for context {}", this);
+            writeLock.unlock();
         }
     }
 

--- a/src/main/java/org/craftercms/engine/service/context/SiteContextFactory.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContextFactory.java
@@ -79,6 +79,7 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
     public static final String DEFAULT_SITE_NAME_MACRO_NAME = "siteName";
     public static final long DEFAULT_INIT_TIMEOUT = 300000L;
     public static final String CONFIG_BEAN_NAME = "siteConfig";
+    public static final long DEFAULT_SHUTDOWN_TIMEOUT = 5;
 
     private static final Log logger = LogFactory.getLog(SiteContextFactory.class);
 
@@ -116,6 +117,7 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
     protected EncryptionAwareConfigurationReader configurationReader;
     protected boolean disableVariableRestrictions;
     protected List<String> defaultPublicBeans;
+    protected long shutdownTimeout;
 
     public SiteContextFactory() {
         siteNameMacroName = DEFAULT_SITE_NAME_MACRO_NAME;
@@ -125,6 +127,7 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
         ignoreHiddenFiles = Context.DEFAULT_IGNORE_HIDDEN_FILES;
         initTimeout = DEFAULT_INIT_TIMEOUT;
         defaultPublicBeans = Collections.emptyList();
+        shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
     }
 
     @Override
@@ -284,6 +287,10 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
         this.defaultPublicBeans = defaultPublicBeans;
     }
 
+    public void setShutdownTimeout(long shutdownTimeout) {
+        this.shutdownTimeout = shutdownTimeout;
+    }
+
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.globalApplicationContext = applicationContext;
@@ -311,6 +318,7 @@ public class SiteContextFactory implements ApplicationContextAware, ServletConte
             siteContext.setRestScriptsPath(restScriptsPath);
             siteContext.setControllerScriptsPath(controllerScriptsPath);
             siteContext.setGraphQLFactory(graphQLFactory);
+            siteContext.setShutdownTimeout(shutdownTimeout);
             if (disableVariableRestrictions) {
                 siteContext.setServletContext(servletContext);
             }

--- a/src/main/resources/crafter/engine/server-config.properties
+++ b/src/main/resources/crafter/engine/server-config.properties
@@ -87,6 +87,8 @@ crafter.engine.site.context.waitForInit=false
 # Time in milliseconds to wait for site initialization
 crafter.engine.site.context.initTimeout=300000
 # Module for AWS configuration profiles
+# Time in minutes to wait for site shutdown
+crafter.engine.site.context.shutdownTimeout=5
 crafter.engine.site.default.config.aws.profiles.module=studio
 # Path where AWS configuration profiles are stored
 crafter.engine.site.default.config.aws.profiles.path=aws/aws.xml

--- a/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -547,6 +547,7 @@
         <property name="configurationReader" ref="crafter.configurationReader"/>
         <property name="disableVariableRestrictions" value="${crafter.engine.disableVariableRestrictions}"/>
         <property name="defaultPublicBeans" value="${creafter.engine.defaultPublicBeans}"/>
+        <property name="shutdownTimeout" value="${crafter.engine.site.context.shutdownTimeout}"/>
     </bean>
 
     <bean id="crafter.fallbackSiteContextFactory" class="org.craftercms.engine.service.context.SiteContextFactory">


### PR DESCRIPTION
- Try to wait for all pending threads to complete before destroying the old context
- Stop the scheduler before the app context to prevent errors on currently running jobs

https://github.com/craftercms/craftercms/issues/3714
