### PR TITLE
Add suppor for site translations:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,11 @@
             <artifactId>commons-collections4</artifactId>
             <version>${commons.collections4.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.gmongo</groupId>

--- a/src/main/java/org/craftercms/engine/freemarker/CrafterFreeMarkerConfigurer.java
+++ b/src/main/java/org/craftercms/engine/freemarker/CrafterFreeMarkerConfigurer.java
@@ -23,6 +23,7 @@ import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import org.craftercms.engine.macro.MacroResolver;
 import org.craftercms.engine.util.freemarker.CrafterCacheAwareConfiguration;
+import org.craftercms.engine.view.freemarker.SiteAwareTemplateLookupStrategy;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
 import java.io.IOException;
@@ -67,6 +68,8 @@ public class CrafterFreeMarkerConfigurer extends FreeMarkerConfigurer {
         if (!cacheTemplates) {
             config.setCacheStorage(NullCacheStorage.INSTANCE);
         }
+
+        config.setTemplateLookupStrategy(new SiteAwareTemplateLookupStrategy());
     }
 
     @Override

--- a/src/main/java/org/craftercms/engine/navigation/impl/LocaleItemFilter.java
+++ b/src/main/java/org/craftercms/engine/navigation/impl/LocaleItemFilter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2007-2020 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.navigation.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.craftercms.core.service.ContentStoreService;
+import org.craftercms.core.service.Item;
+import org.craftercms.core.service.ItemFilter;
+import org.craftercms.engine.service.context.SiteContext;
+import org.craftercms.engine.util.LocaleUtils;
+
+import java.util.List;
+
+import static org.craftercms.commons.locale.LocaleUtils.parseLocale;
+import static org.craftercms.engine.util.LocaleUtils.getCompatibleLocales;
+
+/**
+ * Implementation of {@link ItemFilter} that checks if a given {@link Item} is compatible with the configured locales
+ *
+ * @author joseross
+ * @since 3.2.0
+ */
+public class LocaleItemFilter implements ItemFilter {
+
+    protected String localeCodeXPathQuery;
+
+    protected ContentStoreService contentStoreService;
+
+    public LocaleItemFilter(String localeCodeSelector, ContentStoreService contentStoreService) {
+        this.localeCodeXPathQuery = localeCodeSelector;
+        this.contentStoreService = contentStoreService;
+    }
+
+    @Override
+    public boolean runBeforeProcessing() {
+        return false;
+    }
+
+    @Override
+    public boolean runAfterProcessing() {
+        return true;
+    }
+
+    @Override
+    public boolean accepts(Item item, List<Item> acceptedItems, List<Item> rejectedItems,
+                           boolean runningBeforeProcessing) {
+        // If there is no descriptor, accept it
+        if (item.getDescriptorDom() == null) {
+            return true;
+        }
+
+        // If it has a compatible version, accept it
+        var itemUrl = item.getDescriptorUrl();
+        var localeUrl = LocaleUtils.resolveLocalePath(itemUrl,
+                url -> contentStoreService.exists(SiteContext.getCurrent().getContext(), url));
+
+        if (!StringUtils.equals(itemUrl, localeUrl)) {
+            return true;
+        }
+
+        // If it doesn't have a compatible version, check if the locale code is compatible
+        var itemLocale = parseLocale(item.queryDescriptorValue(localeCodeXPathQuery));
+        if (itemLocale != null) {
+            return getCompatibleLocales().contains(itemLocale);
+        }
+
+        // If it doesn't have a locale code then accept it for backward compatibility
+        return true;
+    }
+
+}

--- a/src/main/java/org/craftercms/engine/navigation/impl/LocaleItemProcessor.java
+++ b/src/main/java/org/craftercms/engine/navigation/impl/LocaleItemProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2007-2020 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.navigation.impl;
+
+import org.craftercms.core.exception.ItemProcessingException;
+import org.craftercms.core.processors.ItemProcessor;
+import org.craftercms.core.service.CachingOptions;
+import org.craftercms.core.service.ContentStoreService;
+import org.craftercms.core.service.Context;
+import org.craftercms.core.service.Item;
+
+import static org.craftercms.engine.util.LocaleUtils.resolveLocalePath;
+
+/**
+ * Implementation of {@link ItemProcessor} that looks for a localized version of an {@link Item}
+ *
+ * @author joseross
+ * @since 3.2.0
+ */
+public class LocaleItemProcessor implements ItemProcessor {
+
+    protected ContentStoreService storeService;
+
+    public LocaleItemProcessor(ContentStoreService storeService) {
+        this.storeService = storeService;
+    }
+
+    @Override
+    public Item process(Context context, CachingOptions cachingOptions, Item item) throws ItemProcessingException {
+
+        if (item != null && item.getDescriptorDom() != null) {
+            return storeService.getItem(context,
+                    resolveLocalePath(item.getDescriptorUrl(), url -> storeService.exists(context, url)));
+        }
+
+        return item;
+    }
+
+}

--- a/src/main/java/org/craftercms/engine/navigation/impl/NavBreadcrumbBuilderImpl.java
+++ b/src/main/java/org/craftercms/engine/navigation/impl/NavBreadcrumbBuilderImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.craftercms.commons.converters.Converter;
 import org.craftercms.commons.lang.UrlUtils;
+import org.craftercms.commons.locale.LocaleUtils;
 import org.craftercms.core.processors.ItemProcessor;
 import org.craftercms.core.processors.impl.ItemProcessorPipeline;
 import org.craftercms.engine.model.SiteItem;
@@ -93,6 +94,7 @@ public class NavBreadcrumbBuilderImpl implements NavBreadcrumbBuilder {
     }
 
     protected String extractBreadcrumbUrl(String url, String root) {
+        url = LocaleUtils.delocalizePath(url);
         String indexFileName = SiteProperties.getIndexFileName();
         String breadcrumbUrl = StringUtils.substringBeforeLast(StringUtils.substringAfter(url, root), indexFileName);
 

--- a/src/main/java/org/craftercms/engine/service/context/SiteContext.java
+++ b/src/main/java/org/craftercms/engine/service/context/SiteContext.java
@@ -56,7 +56,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.craftercms.commons.locale.LocaleUtils.CONFIG_KEY_DEFAULT_LOCALE;
-import static org.craftercms.commons.locale.LocaleUtils.CONFIG_KEY_LOCALE_RESOLVER;
 import static org.craftercms.commons.locale.LocaleUtils.CONFIG_KEY_SUPPORTED_LOCALES;
 
 /**
@@ -390,8 +389,7 @@ public class SiteContext {
     public boolean isTranslationEnabled() {
         return translationConfig != null &&
                 translationConfig.containsKey(CONFIG_KEY_DEFAULT_LOCALE) &&
-                isNotEmpty(translationConfig.configurationsAt(CONFIG_KEY_SUPPORTED_LOCALES)) &&
-                isNotEmpty(translationConfig.configurationsAt(CONFIG_KEY_LOCALE_RESOLVER));
+                isNotEmpty(translationConfig.configurationsAt(CONFIG_KEY_SUPPORTED_LOCALES));
     }
 
     public LocaleResolver getLocaleResolver() {

--- a/src/main/java/org/craftercms/engine/service/impl/SiteItemServiceImpl.java
+++ b/src/main/java/org/craftercms/engine/service/impl/SiteItemServiceImpl.java
@@ -15,12 +15,6 @@
  */
 package org.craftercms.engine.service.impl;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
@@ -46,6 +40,14 @@ import org.craftercms.engine.service.filter.ExpectedNodeValueItemFilter;
 import org.craftercms.engine.service.filter.IncludeByNameItemFilter;
 import org.dom4j.Element;
 import org.springframework.beans.factory.annotation.Required;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.craftercms.engine.util.LocaleUtils.resolveLocalePath;
 
 /**
  * Default implementation of {@link SiteItemService}.
@@ -110,6 +112,7 @@ public class SiteItemServiceImpl implements SiteItemService {
     @Override
     public SiteItem getSiteItem(String url, ItemProcessor processor, Predicate<Item> predicate) {
         SiteContext context = getSiteContext();
+        url = resolveLocalePath(url, u -> storeService.exists(context.getContext(), u));
 
         if(!storeService.exists(context.getContext(), url)) {
             return null;

--- a/src/main/java/org/craftercms/engine/url/RemoveIndexUrlTransformer.java
+++ b/src/main/java/org/craftercms/engine/url/RemoveIndexUrlTransformer.java
@@ -22,6 +22,8 @@ import org.craftercms.core.service.Context;
 import org.craftercms.core.url.UrlTransformer;
 import org.craftercms.engine.properties.SiteProperties;
 
+import static org.craftercms.commons.locale.LocaleUtils.delocalizePath;
+
 /**
  * Created by alfonsovasquez on 7/9/16.
  */
@@ -30,7 +32,7 @@ public class RemoveIndexUrlTransformer implements UrlTransformer {
     @Override
     public String transformUrl(Context context, CachingOptions cachingOptions,
                                String url) throws UrlTransformationException {
-        return StringUtils.removeEnd(url, SiteProperties.getIndexFileName());
+        return StringUtils.removeEnd(delocalizePath(url), SiteProperties.getIndexFileName());
     }
 
 }

--- a/src/main/java/org/craftercms/engine/util/LocaleUtils.java
+++ b/src/main/java/org/craftercms/engine/util/LocaleUtils.java
@@ -35,8 +35,7 @@ import static java.util.Collections.emptyList;
  * @since 3.2.0
  */
 public abstract class LocaleUtils extends org.craftercms.commons.locale.LocaleUtils {
-
-
+    
     public static Locale getCurrentLocale() {
         return LocaleContextHolder.getLocale();
     }

--- a/src/main/java/org/craftercms/engine/util/LocaleUtils.java
+++ b/src/main/java/org/craftercms/engine/util/LocaleUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2007-2020 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.util;
+
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.configuration2.Configuration;
+import org.craftercms.engine.service.context.SiteContext;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Predicate;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Extension of {@link org.craftercms.commons.locale.LocaleUtils} that automatically uses the current locale & fallback
+ * according to the site configuration
+ *
+ * @author joseross
+ * @since 3.2.0
+ */
+public abstract class LocaleUtils extends org.craftercms.commons.locale.LocaleUtils {
+
+
+    public static Locale getCurrentLocale() {
+        return LocaleContextHolder.getLocale();
+    }
+
+    public static boolean isTranslationEnabled() {
+        var context = SiteContext.getCurrent();
+        if (context != null) {
+            return context.isTranslationEnabled();
+        }
+        return false;
+    }
+
+    public static Locale getDefaultLocale() {
+        var context = SiteContext.getCurrent();
+        if (context != null) {
+            return getDefaultLocale(context.getTranslationConfig());
+        }
+        return null;
+    }
+
+    public static Locale getDefaultLocale(Configuration config) {
+        if (config != null) {
+            return parseLocale(config.getString(CONFIG_KEY_DEFAULT_LOCALE, null));
+        }
+        return null;
+    }
+
+    public static boolean isLocaleFallbackEnabled() {
+        var context = SiteContext.getCurrent();
+        if (context != null) {
+            var config = context.getTranslationConfig();
+            if (config != null) {
+                return config.getBoolean(CONFIG_KEY_FALLBACK, false);
+            }
+        }
+        return false;
+    }
+
+    public static List<Locale> getCompatibleLocales() {
+        var currentLocale = LocaleContextHolder.getLocale();
+        var defaultLocale = isLocaleFallbackEnabled()? getDefaultLocale() : null;
+        return getCompatibleLocales(currentLocale, defaultLocale);
+    }
+
+    public static String resolveLocalePath(String path, Predicate<String> exists) {
+        var currentLocale = LocaleContextHolder.getLocale();
+        var defaultLocale = isLocaleFallbackEnabled()? getDefaultLocale() : null;
+        return findPath(path, currentLocale, defaultLocale, exists);
+    }
+
+    public static List<Locale> getSupportedLocales() {
+        var context = SiteContext.getCurrent();
+        if (context != null) {
+            return getSupportedLocales(context.getTranslationConfig());
+        }
+        return emptyList();
+    }
+
+    public static List<Locale> getSupportedLocales(Configuration config) {
+        if (config != null) {
+            return parseLocales(config.getList(String.class, CONFIG_KEY_SUPPORTED_LOCALES)).stream()
+                    .map(locale -> getCompatibleLocales(locale, null))
+                    .reduce(new LinkedList<>(), ListUtils::union);
+        }
+        return emptyList();
+    }
+
+}

--- a/src/main/java/org/craftercms/engine/util/spring/servlet/i18n/PrincipalLocaleResolver.java
+++ b/src/main/java/org/craftercms/engine/util/spring/servlet/i18n/PrincipalLocaleResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2007-2020 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.util.spring.servlet.i18n;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.craftercms.engine.service.context.SiteContext;
+import org.craftercms.engine.util.spring.security.CustomUser;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Locale;
+
+import static org.craftercms.commons.locale.LocaleUtils.parseLocale;
+
+/**
+ * Implementation of {@link ConfigAwareLocaleResolver} that extracts the locale from the current authenticated user
+ *
+ * <p>Supported configuration properties:
+ *  <ul>
+ *      <li><strong>attributeName</strong>: The name of the attribute to use, defaults to {@code preferredLanguage}</li>
+ *  </ul>
+ * </p>
+ *
+ * @author joseross
+ * @since 3.2.0
+ */
+public class PrincipalLocaleResolver extends ConfigAwareLocaleResolver {
+
+    public static final String DEFAULT_ATTRIBUTE_NAME = "preferredLanguage";
+
+    public static final String CONFIG_KEY_ATTRIBUTE_NAME = "attributeName";
+
+    protected String attributeName;
+
+    @Override
+    protected void init(HierarchicalConfiguration<?> config) {
+        attributeName = config.getString(CONFIG_KEY_ATTRIBUTE_NAME, DEFAULT_ATTRIBUTE_NAME);
+    }
+
+    @Override
+    protected Locale resolveLocale(SiteContext siteContext, HttpServletRequest request) {
+        var context = SecurityContextHolder.getContext();
+        if (context != null) {
+            var authentication = context.getAuthentication();
+            if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
+                var principal = (CustomUser) authentication.getPrincipal();
+                if (principal != null) {
+                    return parseLocale(principal.getAttribute(attributeName));
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/org/craftercms/engine/view/freemarker/SiteAwareTemplateLookupStrategy.java
+++ b/src/main/java/org/craftercms/engine/view/freemarker/SiteAwareTemplateLookupStrategy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2007-2020 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.view.freemarker;
+
+import freemarker.cache.TemplateLookupContext;
+import freemarker.cache.TemplateLookupResult;
+import freemarker.cache.TemplateLookupStrategy;
+
+import java.io.IOException;
+
+import static org.craftercms.commons.locale.LocaleUtils.localizePath;
+import static org.craftercms.engine.util.LocaleUtils.getCompatibleLocales;
+
+
+/**
+ * Extension of {@link TemplateLookupStrategy} that looks for locale specific templates
+ *
+ * @author joseross
+ * @since 3.2.0
+ */
+public class SiteAwareTemplateLookupStrategy extends TemplateLookupStrategy {
+
+    @Override
+    public TemplateLookupResult lookup(TemplateLookupContext ctx) throws IOException {
+        var templateName = ctx.getTemplateName();
+
+        var locales = getCompatibleLocales();
+
+        for(var locale : locales) {
+            var localizedTemplate = localizePath(templateName, locale);
+            var result = ctx.lookupWithAcquisitionStrategy(localizedTemplate);
+            if (result.isPositive()) {
+                return result;
+            }
+        }
+
+        return ctx.lookupWithAcquisitionStrategy(templateName);
+    }
+
+}

--- a/src/main/java/org/craftercms/engine/view/freemarker/SiteAwareTemplateLookupStrategy.java
+++ b/src/main/java/org/craftercms/engine/view/freemarker/SiteAwareTemplateLookupStrategy.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import static org.craftercms.commons.locale.LocaleUtils.localizePath;
 import static org.craftercms.engine.util.LocaleUtils.getCompatibleLocales;
 
-
 /**
  * Extension of {@link TemplateLookupStrategy} that looks for locale specific templates
  *

--- a/src/main/resources/crafter/engine/mode/preview/services-context.xml
+++ b/src/main/resources/crafter/engine/mode/preview/services-context.xml
@@ -126,7 +126,6 @@
         <property name="freemarkerSettings">
             <props>
                 <prop key="output_encoding">UTF-8</prop>
-                <prop key="localized_lookup">false</prop>
                 <prop key="object_wrapper">org.craftercms.engine.freemarker.CrafterObjectWrapper</prop>
                 <prop key="datetime_format">${crafter.engine.model.datetime.pattern}</prop>
                 <prop key="time_zone">${crafter.engine.model.datetime.timeZone}</prop>

--- a/src/main/resources/crafter/engine/server-config.properties
+++ b/src/main/resources/crafter/engine/server-config.properties
@@ -176,6 +176,8 @@ crafter.engine.model.expiredDt.xpathQuery=*/expired_dt
 crafter.engine.model.datetime.pattern=yyyy-MM-dd'T'HH:mm:ss.SSSX
 # The TimeZone of _dt fields in the model
 crafter.engine.model.datetime.timeZone=UTC
+# The XPath query to check the locale code of an item
+crafter.engine.model.locale.xpathQuery=*/localeCode
 
 #####################
 # Script Properties #

--- a/src/main/resources/crafter/engine/services/locale-context.xml
+++ b/src/main/resources/crafter/engine/services/locale-context.xml
@@ -33,4 +33,7 @@
         <constructor-arg value="${crafter.engine.locale.cookie.name}"/>
     </bean>
 
+    <bean id="crafter.principalLocaleResolver" scope="prototype"
+          class="org.craftercms.engine.util.spring.servlet.i18n.PrincipalLocaleResolver"/>
+
 </beans>

--- a/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -672,7 +672,6 @@
         <property name="freemarkerSettings">
             <props>
                 <prop key="output_encoding">UTF-8</prop>
-                <prop key="localized_lookup">false</prop>
                 <prop key="object_wrapper">org.craftercms.engine.freemarker.CrafterObjectWrapper</prop>
                 <prop key="datetime_format">${crafter.engine.model.datetime.pattern}</prop>
                 <prop key="time_zone">${crafter.engine.model.datetime.timeZone}</prop>
@@ -770,6 +769,10 @@
         <property name="targetIdManager" ref="crafter.proxyTargetIdManager"/>
     </bean>
 
+    <bean id="crafter.localeItemProcessor" class="org.craftercms.engine.navigation.impl.LocaleItemProcessor">
+        <constructor-arg ref="crafter.contentStoreService"/>
+    </bean>
+
     <bean id="crafter.rejectIndexFilesItemFilter"
           class="org.craftercms.engine.navigation.impl.RejectIndexFilesItemFilter">
         <property name="targetedUrlStrategy" ref="crafter.proxyTargetedUrlStrategy"/>
@@ -784,12 +787,19 @@
         <constructor-arg value="true"/>
     </bean>
 
+    <bean id="crafter.localeItemFilter" class="org.craftercms.engine.navigation.impl.LocaleItemFilter">
+        <constructor-arg value="${crafter.engine.model.locale.xpathQuery}"/>
+        <constructor-arg ref="crafter.contentStoreService"/>
+    </bean>
+
     <util:list id="crafter.navTreeProcessors">
         <ref bean="crafter.folderToIndexItemProcessor"/>
         <ref bean="crafter.currentTargetedVersionItemProcessor"/>
+        <ref bean="crafter.localeItemProcessor"/>
     </util:list>
 
     <util:list id="crafter.navTreeFilters">
+        <ref bean="crafter.localeItemFilter"/>
         <ref bean="crafter.rejectIndexFilesItemFilter"/>
         <ref bean="crafter.rejectDuplicatesItemFilter"/>
         <ref bean="crafter.acceptPlaceInNavItemFilter"/>


### PR DESCRIPTION
- Support localized descriptors, templates, navigation & breadcrumbs
- Add new locale resolver to use the current authenticated user
- Add new parameters to override locales for search & graphql

craftercms/craftercms#4022
https://github.com/craftercms/craftercms/issues/4021

Depends on https://github.com/craftercms/commons/pull/241