### PR TITLE
Cookie the Response with a CrafterSite when Request is sent with a Preview Token QSA

### DIFF
--- a/src/main/java/org/craftercms/engine/util/http/SameSite.java
+++ b/src/main/java/org/craftercms/engine/util/http/SameSite.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.craftercms.engine.util.http;
+
+/**
+ * Enum representing the SameSite attribute for cookies.
+ * <p>
+ * This enum defines the possible values for the SameSite attribute, which is used to control
+ * whether cookies are sent with cross-site requests. The values are:
+ * <ul>
+ *     <li>Strict: Cookies are only sent in a first-party context.</li>
+ *     <li>Lax: Cookies are sent in a first-party context and with top-level navigation.</li>
+ *     <li>None: Cookies are sent in all contexts, including cross-origin requests.</li>
+ * </ul>
+ */
+public enum SameSite {
+	STRICT("Strict"),
+	LAX("Lax"),
+	NONE("None");
+
+	private final String value;
+
+	SameSite(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public static SameSite fromValue(String value) {
+		for (SameSite s : values()) {
+			if (s.value.equalsIgnoreCase(value)) {
+				return s;
+			}
+		}
+		throw new IllegalArgumentException("Invalid SameSite value: " + value);
+	}
+}
+

--- a/src/main/java/org/craftercms/engine/util/spring/security/preview/ConfigAwarePreviewAccessTokenFilter.java
+++ b/src/main/java/org/craftercms/engine/util/spring/security/preview/ConfigAwarePreviewAccessTokenFilter.java
@@ -19,8 +19,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.collections4.CollectionUtils;
+import jakarta.servlet.http.HttpServletResponse;
 import org.craftercms.commons.crypto.CryptoException;
 import org.craftercms.commons.crypto.TextEncryptor;
 import org.craftercms.commons.http.HttpUtils;
@@ -34,7 +35,6 @@ import org.springframework.web.filter.GenericFilterBean;
 
 import java.beans.ConstructorProperties;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -43,6 +43,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Filter that checks if the user is authorized to preview the site.
+ * If the authorized token is from the QSA, it will set the cookies to support preview workflow.
  */
 public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 	private final static String PREVIEW_SITE_TOKEN_NAME = "crafterPreview";
@@ -50,17 +51,21 @@ public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 
 	private final TextEncryptor textEncryptor;
 	private final SiteAwareCorsConfigurationSource corsConfigSource;
+	private final String siteNameParam;
 
-	@ConstructorProperties({"textEncryptor", "corsConfigSource"})
+	@ConstructorProperties({"textEncryptor", "corsConfigSource", "siteNameParam"})
 	public ConfigAwarePreviewAccessTokenFilter(final TextEncryptor textEncryptor,
-											   final SiteAwareCorsConfigurationSource corsConfigSource) {
+											   final SiteAwareCorsConfigurationSource corsConfigSource,
+											   final String siteNameParam) {
 		this.textEncryptor = textEncryptor;
 		this.corsConfigSource = corsConfigSource;
+		this.siteNameParam = siteNameParam;
 	}
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
 		String site = SiteContext.getCurrent().getSiteName();
 		if (isEmpty(site)) {
 			chain.doFilter(request, response);
@@ -72,9 +77,11 @@ public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 			return;
 		}
 
+		boolean tokenFromQueryParam = false;
 		String previewToken = httpServletRequest.getHeader(PREVIEW_SITE_TOKEN_HEADER_NAME);
 		if (isEmpty(previewToken)) {
 			previewToken = httpServletRequest.getParameter(PREVIEW_SITE_TOKEN_NAME);
+			tokenFromQueryParam = !isEmpty(previewToken);
 		}
 		if (isEmpty(previewToken)) {
 			previewToken = HttpUtils.getCookieValue(PREVIEW_SITE_TOKEN_NAME, httpServletRequest);
@@ -95,8 +102,8 @@ public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 			throw new PreviewAccessException(HttpStatus.UNAUTHORIZED, message);
 		}
 
-		long tokenTimestamp = Long.parseLong(tokens[1]);
-		boolean isExpired = tokenTimestamp < System.currentTimeMillis();
+		long tokenExpiryTimestamp = Long.parseLong(tokens[1]);
+		boolean isExpired = tokenExpiryTimestamp < System.currentTimeMillis();
 		if (isExpired) {
 			String message = format("User is not authorized to preview site '%s', '%s' header or '%s' token has expired",
 				site, PREVIEW_SITE_TOKEN_HEADER_NAME, PREVIEW_SITE_TOKEN_NAME);
@@ -113,7 +120,60 @@ public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 			throw new PreviewAccessException(HttpStatus.FORBIDDEN, message);
 		}
 
+		// Create preview token and site name cookies to support preview workflow
+		int maxAge = Math.max((int)((tokenExpiryTimestamp - System.currentTimeMillis()) / 1000), 0);
+		if (tokenFromQueryParam && maxAge > 0) {
+			createPreviewCookie(httpServletRequest, httpServletResponse, previewToken, maxAge);
+			createSiteNameCookie(httpServletRequest, httpServletResponse, maxAge);
+		}
+
 		chain.doFilter(request, response);
+	}
+
+	/**
+	 * Creates a preview cookie with the given token.
+	 *
+	 * @param request the HTTP request
+	 * @param response the HTTP response
+	 * @param previewToken the preview token
+	 * @param  maxAge the max-age value
+	 */
+	private void createPreviewCookie(HttpServletRequest request, HttpServletResponse response, String previewToken, int maxAge) {
+		createCookie(request, response, PREVIEW_SITE_TOKEN_NAME, previewToken, maxAge);
+	}
+
+	/**
+	 * Creates a cookie with the site name.
+	 *
+	 * @param request the HTTP request
+	 * @param response the HTTP response
+	 * @param maxAge the max-age value
+	 */
+	private void createSiteNameCookie(HttpServletRequest request, HttpServletResponse response, int maxAge) {
+		String siteName = request.getParameter(siteNameParam);
+		if (isEmpty(siteName)) {
+			return;
+		}
+
+		createCookie(request, response, siteNameParam, siteName, maxAge);
+	}
+
+	/**
+	 * Creates a cookie with the given name and value.
+	 *
+	 * @param request the HTTP request
+	 * @param response the HTTP response
+	 * @param name the name of the cookie
+	 * @param value the value of the cookie
+	 * @param maxAge the max-age value
+	 */
+	private void createCookie(HttpServletRequest request, HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setSecure(request.isSecure());
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
 	}
 
 	/**

--- a/src/main/java/org/craftercms/engine/util/spring/security/preview/ConfigAwarePreviewAccessTokenFilter.java
+++ b/src/main/java/org/craftercms/engine/util/spring/security/preview/ConfigAwarePreviewAccessTokenFilter.java
@@ -27,6 +27,7 @@ import org.craftercms.commons.crypto.TextEncryptor;
 import org.craftercms.commons.http.HttpUtils;
 import org.craftercms.engine.exception.PreviewAccessException;
 import org.craftercms.engine.service.context.SiteContext;
+import org.craftercms.engine.util.http.SameSite;
 import org.craftercms.engine.util.spring.cors.SiteAwareCorsConfigurationSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.cors.CorsConfiguration;
@@ -52,14 +53,22 @@ public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 	private final TextEncryptor textEncryptor;
 	private final SiteAwareCorsConfigurationSource corsConfigSource;
 	private final String siteNameParam;
+	private final String cookiePath;
+	private final boolean cookieHttpOnly;
+	private final SameSite cookieSameSite;
 
-	@ConstructorProperties({"textEncryptor", "corsConfigSource", "siteNameParam"})
+	@ConstructorProperties({"textEncryptor", "corsConfigSource", "siteNameParam", "cookiePath", "cookieHttpOnly",
+		"cookieSameSite"})
 	public ConfigAwarePreviewAccessTokenFilter(final TextEncryptor textEncryptor,
 											   final SiteAwareCorsConfigurationSource corsConfigSource,
-											   final String siteNameParam) {
+											   final String siteNameParam, final String cookiePath,
+											   boolean cookieHttpOnly, String cookieSameSite) {
 		this.textEncryptor = textEncryptor;
 		this.corsConfigSource = corsConfigSource;
 		this.siteNameParam = siteNameParam;
+		this.cookiePath = cookiePath;
+		this.cookieHttpOnly = cookieHttpOnly;
+		this.cookieSameSite = SameSite.fromValue(cookieSameSite);
 	}
 
 	@Override
@@ -169,9 +178,9 @@ public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 	 */
 	private void createCookie(HttpServletRequest request, HttpServletResponse response, String name, String value, int maxAge) {
 		Cookie cookie = new Cookie(name, value);
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
-		cookie.setAttribute("SameSite", "Strict");
+		cookie.setPath(cookiePath);
+		cookie.setHttpOnly(cookieHttpOnly);
+		cookie.setAttribute("SameSite", cookieSameSite.getValue());
 		cookie.setSecure(request.isSecure());
 		cookie.setMaxAge(maxAge);
 		response.addCookie(cookie);

--- a/src/main/java/org/craftercms/engine/util/spring/security/preview/ConfigAwarePreviewAccessTokenFilter.java
+++ b/src/main/java/org/craftercms/engine/util/spring/security/preview/ConfigAwarePreviewAccessTokenFilter.java
@@ -171,6 +171,7 @@ public class ConfigAwarePreviewAccessTokenFilter extends GenericFilterBean {
 		Cookie cookie = new Cookie(name, value);
 		cookie.setPath("/");
 		cookie.setHttpOnly(true);
+		cookie.setAttribute("SameSite", "Strict");
 		cookie.setSecure(request.isSecure());
 		cookie.setMaxAge(maxAge);
 		response.addCookie(cookie);

--- a/src/main/resources/crafter/engine/mode/preview/security-context.xml
+++ b/src/main/resources/crafter/engine/mode/preview/security-context.xml
@@ -63,6 +63,7 @@
 				<bean class="org.craftercms.engine.util.spring.security.preview.ConfigAwarePreviewAccessTokenFilter">
 					<constructor-arg name="encryptor" ref="crafter.textEncryptor"/>
 					<constructor-arg name="corsConfigSource" ref="crafter.corsConfigSource" />
+					<constructor-arg name="siteNameParam" value="${crafter.engine.request.param.siteName}"/>
 				</bean>
 			</util:list>
 		</constructor-arg>

--- a/src/main/resources/crafter/engine/mode/preview/security-context.xml
+++ b/src/main/resources/crafter/engine/mode/preview/security-context.xml
@@ -64,6 +64,9 @@
 					<constructor-arg name="encryptor" ref="crafter.textEncryptor"/>
 					<constructor-arg name="corsConfigSource" ref="crafter.corsConfigSource" />
 					<constructor-arg name="siteNameParam" value="${crafter.engine.request.param.siteName}"/>
+					<constructor-arg name="cookiePath" value="${crafter.security.preview.cookie.path}"/>
+					<constructor-arg name="cookieHttpOnly" value="${crafter.security.preview.cookie.httpOnly}"/>
+					<constructor-arg name="cookieSameSite" value="${crafter.security.preview.cookie.sameSite}"/>
 				</bean>
 			</util:list>
 		</constructor-arg>

--- a/src/main/resources/crafter/engine/mode/preview/server-config.properties
+++ b/src/main/resources/crafter/engine/mode/preview/server-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+# Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as published by
@@ -31,3 +31,11 @@ crafter.security.preview.urlsToExclude=\
     /api/1/monitoring/**,\
     /api/1/site/context/**,\
     /api/1/site/cache/**
+# The path attribute to set cookies for the preview security filters
+crafter.security.preview.cookie.path=/
+# The HttpOnly flag attribute to set cookies for the preview security filters
+crafter.security.preview.cookie.httpOnly=true
+# The SameSite attribute to set cookies for the preview security filters
+# Possible values: None, Lax, Strict
+# SameSite None requires the connection to be secure (HTTPS)
+crafter.security.preview.cookie.sameSite=Strict


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/1119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preview access now sets cookies for the preview token and site name when the token is provided via a query parameter, improving workflow continuity.
- **Improvements**
  - Enhanced preview workflow support for scenarios where tokens are passed as query parameters.
  - Added support for configuring cookie attributes such as path, HttpOnly, and SameSite for preview tokens.
  - Introduced consistent handling of SameSite cookie attributes with new configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->