### PR TITLE
Explicitly add annotationProcessors list in order to disable new GraalVmProcessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,16 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessors>
+						<!-- List processors explicitly -->
+						<annotationProcessor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</annotationProcessor>
+					</annotationProcessors>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<configuration>
 					<attachClasses>true</attachClasses>


### PR DESCRIPTION
Explicitly add annotationProcessors list in order to disable new GraalVmProcessor

