### PR TITLE
Fix depth parameter in recursion in navigationItem macro

### DIFF
--- a/src/main/webapp/WEB-INF/templates/system/common/navigation.ftl
+++ b/src/main/webapp/WEB-INF/templates/system/common/navigation.ftl
@@ -159,7 +159,7 @@ subItemClassPrefix=subItemClassPrefix
 subItemWrapperClass=subItemWrapperClass
 subItemWrapperClassPrefix=subItemWrapperClassPrefix
 subItemContainerClass=subItemContainerClass
-depth=(inlineRootWithImmediateChildren && currentDepth == 0)?then(depth - 1, currentDepth +1)
+depth=depth - 1
 currentDepth=(inlineRootWithImmediateChildren && currentDepth == 0)?then(currentDepth, currentDepth + 1)
 navItem=subItem
 inlineRootWithImmediateChildren=false


### PR DESCRIPTION
Fix depth parameter in recursion in navigationItem macro
https://github.com/craftercms/craftercms/issues/8245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected navigation depth handling for nested menus, ensuring consistent indentation and visibility of sub-items.
  * Improved behavior when displaying the root with its immediate children, preventing skipped or mis-leveled entries.
  * Results in more predictable expansion and highlighting across multi-level navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->