### PR TITLE
Make search connection pool configurable

### DIFF
--- a/src/main/resources/crafter/engine/server-config.properties
+++ b/src/main/resources/crafter/engine/server-config.properties
@@ -292,6 +292,10 @@ crafter.engine.search.threads=-1
 crafter.engine.search.keepAlive=false
 # The filters that should be executed on all ES queries
 crafter.engine.search.filters=-disabled:"true",-expired_dt:[* TO now]
+# The max total connections, if set to -1 the default will be used
+crafter.engine.search.maxTotalConnections=-1
+# The max connections per route, if set to -1 the default will be used
+crafter.engine.search.maxConnectionsPerRoute=-1
 ######################
 # GraphQL Properties #
 ######################

--- a/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -716,6 +716,8 @@
 				<property name="socketTimeout" ref="crafter.searchSocketTimeout"/>
 				<property name="threadCount" ref="crafter.searchThreadCount"/>
 				<property name="socketKeepAlive" ref="crafter.searchSocketKeepAlive"/>
+				<property name="maxTotalConnections" value="${crafter.engine.search.maxTotalConnections}"/>
+				<property name="maxConnectionsPerRoute" value="${crafter.engine.search.maxConnectionsPerRoute}"/>
 			</bean>
 		</constructor-arg>
 		<constructor-arg name="indexIdFormat" value="${crafter.engine.search.index.format}"/>
@@ -735,6 +737,8 @@
 				<property name="socketTimeout" ref="crafter.searchSocketTimeout"/>
 				<property name="threadCount" ref="crafter.searchThreadCount"/>
 				<property name="socketKeepAlive" ref="crafter.searchSocketKeepAlive"/>
+				<property name="maxTotalConnections" value="${crafter.engine.search.maxTotalConnections}"/>
+				<property name="maxConnectionsPerRoute" value="${crafter.engine.search.maxConnectionsPerRoute}"/>
 			</bean>
 		</constructor-arg>
 		<constructor-arg name="indexIdFormat" value="${crafter.engine.search.index.format}"/>


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8344
Make search connection pool configurable

Notice this PR is dependent on https://github.com/craftercms/search/pull/348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configuration options to control search connection pooling: maximum total connections and maximum connections per route. Defaults apply when not set, enabling better tuning for different workloads.
- Chores
  - Updated service configuration to consume the new connection pool settings for the search client, improving configurability without changing existing behavior by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->