### PR TITLE
Allow 'site' scheme in URLs for site configuration files

### DIFF
--- a/src/main/resources/crafter/engine/server-config.properties
+++ b/src/main/resources/crafter/engine/server-config.properties
@@ -495,3 +495,8 @@ crafter.engine.watcher.ignorePaths=\
 crafter.engine.watcher.counter.limit=5
 # Engine file change watcher thread interval in milliseconds
 crafter.engine.watcher.interval.period=200
+
+# Used to set the system property 'org.apache.commons.configuration2.io.FileLocationStrategy.schemes', which is a list of the
+# allowed URL schemes for configuration file locations. By default, it includes 'file' and 'jar', we add the custom 'site' scheme
+# for site configuration files. See org.craftercms.engine.util.url.ContentStoreUrlStreamHandler
+crafter.engine.configuration.schemes=file,jar,site

--- a/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -118,6 +118,7 @@
             <map>
                 <entry key="crafter.modePreview" value="${crafter.engine.preview}"/>
                 <entry key="crafter.environment" value="${crafter.engine.environment}"/>
+                <entry key="org.apache.commons.configuration2.io.FileLocationStrategy.schemes" value="${crafter.engine.configuration.schemes}"/>
             </map>
         </property>
     </bean>


### PR DESCRIPTION
Allow 'site' scheme in URLs for site configuration files
https://github.com/craftersoftware/craftercms/issues/1251