### PR TITLE
Allow 'site' scheme in URLs for site configuration files

### DIFF
--- a/src/main/resources/crafter/engine/server-config.properties
+++ b/src/main/resources/crafter/engine/server-config.properties
@@ -471,3 +471,9 @@ crafter.engine.watcher.interval.period=200
 crafter.engine.api.stripSuffixes.suffixes=.json,.xml
 # Urls to include for suffix stripping
 crafter.engine.api.stripSuffixes.includedUrls=/api/**
+
+# Used to set the system property 'org.apache.commons.configuration2.io.FileLocationStrategy.schemes', which is a list of the
+# allowed URL schemes for configuration file locations. By default, it includes 'file' and 'jar', we add the custom 'site' scheme
+# for site configuration files. See org.craftercms.engine.util.url.ContentStoreUrlStreamHandler
+crafter.engine.configuration.schemes=file,jar,site
+

--- a/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+  * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License version 3 as published by
@@ -118,6 +118,7 @@
 			<map>
 				<entry key="crafter.modePreview" value="${crafter.engine.preview}"/>
 				<entry key="crafter.environment" value="${crafter.engine.environment}"/>
+				<entry key="org.apache.commons.configuration2.io.FileLocationStrategy.schemes" value="${crafter.engine.configuration.schemes}"/>
 			</map>
 		</property>
 	</bean>


### PR DESCRIPTION
Allow 'site' scheme in URLs for site configuration files
https://github.com/craftersoftware/craftercms/issues/1251