### PR TITLE
Reduce INFO logging for rejected requests

### DIFF
--- a/src/main/java/org/craftercms/engine/http/impl/MinimalLoggingRequestRejectedHandler.java
+++ b/src/main/java/org/craftercms/engine/http/impl/MinimalLoggingRequestRejectedHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.http.impl;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.security.web.firewall.RequestRejectedHandler;
+
+import java.io.IOException;
+
+/**
+ * {@link RequestRejectedHandler} implementation that logs the exception with a minimal message and stack trace when debug is enabled, and only the message when debug is disabled.
+ * It also allows configuring the HTTP status code to be sent in the response.
+ */
+public class MinimalLoggingRequestRejectedHandler implements RequestRejectedHandler {
+	private static final Logger logger = LoggerFactory.getLogger(MinimalLoggingRequestRejectedHandler.class);
+
+	private final int httpError;
+
+	/**
+	 * Constructs an instance which uses {@code 400} as response code.
+	 */
+	public MinimalLoggingRequestRejectedHandler() {
+		this(HttpServletResponse.SC_BAD_REQUEST);
+	}
+
+	/**
+	 * Constructs an instance which uses a configurable http code as response.
+	 *
+	 * @param httpError http status code to use
+	 */
+	public MinimalLoggingRequestRejectedHandler(int httpError) {
+		this.httpError = httpError;
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, RequestRejectedException e) throws IOException {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Rejecting request due to: {}", e.getMessage(), e);
+		} else {
+			logger.info("Rejecting request due to: {}", e.getMessage());
+		}
+		response.sendError(this.httpError);
+	}
+}

--- a/src/main/resources/crafter/engine/mode/preview/security-context.xml
+++ b/src/main/resources/crafter/engine/mode/preview/security-context.xml
@@ -74,6 +74,9 @@
 
 	<bean id="crafter.previewSecurityFilter" class="org.springframework.security.web.FilterChainProxy">
 		<constructor-arg index="0" ref="crafter.previewSecurityFilterChain"/>
+		<property name="requestRejectedHandler">
+			<bean class="org.craftercms.engine.http.impl.MinimalLoggingRequestRejectedHandler"/>
+		</property>
 	</bean>
 
 	<util:list id="crafter.authenticationProviders">

--- a/src/main/resources/crafter/engine/services/security-context.xml
+++ b/src/main/resources/crafter/engine/services/security-context.xml
@@ -271,6 +271,9 @@
 
 	<bean id="crafter.securityFilter" class="org.springframework.security.web.FilterChainProxy">
 		<constructor-arg index="0" ref="crafter.securityFilterChain"/>
+		<property name="requestRejectedHandler">
+			<bean class="org.craftercms.engine.http.impl.MinimalLoggingRequestRejectedHandler"/>
+		</property>
 	</bean>
 
 	<!--    This is meant to be in preview mode context with a PreviewAccessTokenFilter -->


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7833
Reduce INFO logging for rejected requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized handling of rejected security requests with minimal logging output to reduce log clutter—logs only messages in standard mode, with stack traces available in debug mode
  * Custom rejection handler now consistently applied to both preview and main security filters with configurable HTTP error codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->